### PR TITLE
chore: configure cli run command to run qualification profile by default (#759)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -254,8 +254,11 @@ command -v esq &> /dev/null && echo "[OK] esq installed: $(esq --version 2>&1)" 
 # ALWAYS list profiles first to verify correct profile names
 esq list
 
-# Run all profiles
+# Run qualification profiles only (default behavior)
 esq -v run
+
+# Run all profile types (qualifications, suites, verticals)
+esq -v run --all
 
 # Run specific profile (use exact name from 'esq list')
 esq -d run --profile profile.suite.ai.vision

--- a/src/esq/utils/models/export_model.py
+++ b/src/esq/utils/models/export_model.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # source: https://github.com/openvinotoolkit/model_server/blob/main/demos/common/export_models/export_model.py
-# commit: 3127325
+# commit: 3127325 (Oct 22, 2025)
 
 import argparse
 import json
@@ -458,7 +458,7 @@ node: {
           {%- if pipeline_type %}
           pipeline_type: {{pipeline_type}},{% endif %}
           models_path: "{{model_path}}",
-          plugin_config: '{{plugin_config}}',
+          plugin_config: '{{plugin_config|safe}}',
           enable_prefix_caching: {% if not enable_prefix_caching %}false{% else %} true{% endif%},
           cache_size: {{cache_size|default("10", true)}},
           {%- if max_num_batched_tokens %}
@@ -541,7 +541,7 @@ node: {
     [type.googleapis.com / mediapipe.ImageGenCalculatorOptions]: {
       models_path: "{{model_path}}",
       {%- if plugin_config_str %}
-      plugin_config: '{{plugin_config_str}}',{% endif %}
+      plugin_config: '{{plugin_config_str|safe}}',{% endif %}
       device: "{{target_device|default("CPU", true)}}",
       {%- if resolution %}
       resolution: "{{resolution}}",{% endif %}

--- a/src/sysagent/cli.py
+++ b/src/sysagent/cli.py
@@ -101,6 +101,7 @@ def main() -> int:
                 skip_system_check=args.skip_system_check,
                 no_cache=args.no_cache,
                 filters=args.filter,
+                run_all_profiles=args.all,
                 extra_args=[],  # No extra args from command line
             )
         elif args.command == "info":

--- a/src/sysagent/utils/cli/parsers.py
+++ b/src/sysagent/utils/cli/parsers.py
@@ -49,25 +49,29 @@ def create_argument_parser() -> argparse.ArgumentParser:
     # Run command
     run_parser = subparsers.add_parser(
         "run",
-        help="Run tests (all profiles, specific profile, or individual tests)",
+        help="Run tests (qualification profiles by default, specific profile, or individual tests)",
         description=f"""
-Run tests using one of three main patterns:
+Run tests using one of four main patterns:
 
 USAGE PATTERNS:
-  1. Run all available profiles:
+  1. Run all qualification profiles (default):
      {cli_name} run
 
-  2. Run a specific profile:
+  2. Run all available profiles:
+     {cli_name} run --all
+
+  3. Run a specific profile:
      {cli_name} run -p PROFILE_NAME
 
-  3. Run with filters:
+  4. Run with filters:
      {cli_name} run -p PROFILE_NAME --filter test_id=T0069
      {cli_name} run -p PROFILE_NAME --filter display_name="CPU Test"
      {cli_name} run -p PROFILE_NAME --filter test_id=T0069 --filter devices=cpu
 
 EXAMPLES:
-  {cli_name} run                                # Run all profiles
-  {cli_name} run -p profile.suite.ai.vision     # Run specific profile
+  {cli_name} run                                      # Run qualification profiles only (default)
+  {cli_name} run --all                                # Run all profile types
+  {cli_name} run -p profile.suite.ai.vision           # Run specific profile
 
 For available profiles, use: {cli_name} list
         """,
@@ -76,6 +80,15 @@ For available profiles, use: {cli_name} list
 
     # Main execution options (grouped for clarity)
     execution_group = run_parser.add_argument_group("EXECUTION OPTIONS")
+    execution_group.add_argument(
+        "--all",
+        "-a",
+        action="store_true",
+        help=(
+            "Run all profile types (qualifications, suites, verticals). "
+            "By default, only qualification profiles are run."
+        ),
+    )
     execution_group.add_argument(
         "--profile", "-p", metavar="PROFILE_NAME", help="Run a specific profile (e.g., profile.suite.ai-vision)"
     )


### PR DESCRIPTION
chore: configure cli run command to run qualification profile by default (#759)

* chore: configure cli run command to run qualification profile by default

* fix: autoescape for security compliance has cause plugin config in graph.pbtxt to create as wrong format
