### PR TITLE
chore: update Vision AI benchmark mainstream reference streams (#780)

### DIFF
--- a/src/esq/configs/profiles/qualifications/ai_edge_system.yml
+++ b/src/esq/configs/profiles/qualifications/ai_edge_system.yml
@@ -315,7 +315,7 @@ suites:
                 kpi_override:
                   streams_max:
                     validation:
-                      reference: 7
+                      reference: 5
                       enabled: true
 
               # Efficiency Optimized


### PR DESCRIPTION
chore: update Vision AI benchmark mainstream reference streams (#780)

* chore: update Vision AI benchmark mainstream reference KPI from 7 to 5 streams

* fix: shellcheck scan issues
