### PR TITLE
fix: baseline streams analysis for GPU.2 did not return valid results (#796)

### DIFF
--- a/src/esq/suites/ai/vision/src/containers/dlstreamer_analyzer/Dockerfile.dgpu
+++ b/src/esq/suites/ai/vision/src/containers/dlstreamer_analyzer/Dockerfile.dgpu
@@ -1,0 +1,43 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+# Install additional required packages for dGPU compatibility
+
+# FROM intel/dlstreamer:2025.0.1.3-ubuntu24
+FROM intel/dlstreamer:2025.1.2-ubuntu24
+# FROM intel/dlstreamer:2025.1.2-ubuntu22
+
+USER root
+
+# Set up directories with proper ownership (dlstreamer user already exists with UID 1000)
+RUN mkdir -p /app && \
+    chown dlstreamer:dlstreamer /app
+
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y \
+        intel-opencl-icd \
+        python3-gi \
+        python3-gst-1.0 \
+        gir1.2-gst-plugins-base-1.0 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy main.py and make it executable
+COPY main.py /app/main.py
+RUN chmod +x /app/main.py && \
+    chown dlstreamer:dlstreamer /app/main.py
+
+# Set up workspace with secure permissions
+RUN mkdir -p /mnt/results /mnt/logs /mnt/videos && \
+    chmod 770 /mnt /mnt/results /mnt/logs /mnt/videos && \
+    chown -R dlstreamer:dlstreamer /mnt
+
+# Add healthcheck for operational monitoring and security compliance
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+    CMD python3 --version || exit 1
+
+WORKDIR /app
+
+# Switch to non-root user
+USER dlstreamer
+
+ENTRYPOINT ["/app/main.py"]

--- a/src/esq/suites/ai/vision/src/dlstreamer/execution.py
+++ b/src/esq/suites/ai/vision/src/dlstreamer/execution.py
@@ -11,6 +11,7 @@ from typing import Any, Dict
 from sysagent.utils.core import Metrics, Result, get_metric_name_for_device
 from sysagent.utils.system.ov_helper import get_openvino_device_type
 
+from .preparation import get_device_specific_docker_image
 from .qualification import qualify_device
 
 logger = logging.getLogger(__name__)
@@ -35,6 +36,7 @@ def run_device_test(
     metrics=None,
     baseline_streams=None,
     visualize_stream: bool = False,
+    container_config: Dict[str, Any] = None,
 ) -> Result:
     """
     Execute DL Streamer test for a single device.
@@ -46,11 +48,18 @@ def run_device_test(
         metrics: Default metrics for the device
         baseline_streams: Baseline stream information
         visualize_stream: Whether to visualize the stream
+        container_config: Container configuration with available images (optional)
 
     Returns:
         Result object with test outcomes
     """
     logger.info(f"Executing DL Streamer test for device: {device_id}")
+
+    # Select device-specific Docker image
+    if container_config:
+        docker_image_tag_analyzer = get_device_specific_docker_image(
+            device_id, container_config, docker_image_tag_analyzer, device_dict
+        )
 
     result = Result(
         parameters={
@@ -97,6 +106,7 @@ def run_device_test(
             num_sockets=num_sockets,
             max_plateau_iterations=max_plateau_iterations,
             visualize_stream=visualize_stream,
+            container_config=container_config,
         )
         final_results[device_id] = device_result
 


### PR DESCRIPTION
fix: baseline streams analysis for GPU.2 did not return valid results (#796)

* fix: baseline streams analysis for GPU.2 did not return valid results

* feat: enable separate container image for dlstreamer analysis on dgpu
- feat: add support for dockerclient to automatically extract apt package list and base image digest
