### PR TITLE
fix: dlstreamer analysis spawns only single container for 2-socket CPU (#829)

### DIFF
--- a/src/esq/suites/ai/vision/src/dlstreamer/execution.py
+++ b/src/esq/suites/ai/vision/src/dlstreamer/execution.py
@@ -354,6 +354,7 @@ def update_final_results_metadata(
     device_list: list,
     baseline_streams_results: list = None,
     requested_device_categories: list = None,
+    target_fps: float = None,
 ) -> None:
     """
     Update final results with device metadata and summary information.
@@ -365,6 +366,7 @@ def update_final_results_metadata(
         device_list: List of all device IDs tested
         baseline_streams_results: List of baseline preparation results (optional)
         requested_device_categories: List of device categories requested in config (optional)
+        target_fps: Target FPS for stream qualification (optional)
     """
     if baseline_streams_results:
         baseline_fps_count = 0
@@ -375,6 +377,17 @@ def update_final_results_metadata(
                 results.metadata[f"Baseline Pipeline Throughput (FPS) - {device_id}"] = f"{per_stream_fps:.2f}"
                 baseline_fps_count += 1
                 logger.debug(f"Adding baseline pipeline throughput FPS for {device_id}: {per_stream_fps:.2f}")
+
+                # Calculate estimated max streams based on baseline FPS / target FPS
+                if target_fps and target_fps > 0 and per_stream_fps > 0:
+                    estimated_max_streams = int(per_stream_fps / target_fps)
+                    results.metadata[f"Estimated Max Streams (Baseline / Target FPS) - {device_id}"] = (
+                        estimated_max_streams
+                    )
+                    logger.debug(
+                        f"Estimated max streams for {device_id}: {estimated_max_streams} "
+                        f"(baseline {per_stream_fps:.2f} FPS / target {target_fps:.2f} FPS)"
+                    )
 
         if baseline_fps_count > 0:
             logger.info(f"Baseline per-stream FPS captured for {baseline_fps_count} device(s)")

--- a/src/esq/suites/ai/vision/test_dlstreamer.py
+++ b/src/esq/suites/ai/vision/test_dlstreamer.py
@@ -114,7 +114,7 @@ def test_dlstreamer(
     # Get current system info
     system_info = SystemInfoCache()
     hardware_info = system_info.get_hardware_info()
-    num_sockets = hardware_info.get("cpu", {}).get("socket_count", 1)
+    num_sockets = hardware_info.get("cpu", {}).get("sockets") or 1
 
     # Use modularized cleanup functions
     def cleanup() -> None:
@@ -403,7 +403,12 @@ def test_dlstreamer(
 
         # Update final results metadata using modular function
         update_final_results_metadata(
-            results, qualified_devices, device_list, baseline_streams_results, requested_device_categories=devices
+            results,
+            qualified_devices,
+            device_list,
+            baseline_streams_results,
+            requested_device_categories=devices,
+            target_fps=target_fps,
         )
 
         logger.debug(f"DL Streamer Test results: {json.dumps(results.to_dict(), indent=2)}")
@@ -454,6 +459,7 @@ def test_dlstreamer(
                     device_list,
                     baseline_streams_results,
                     requested_device_categories=devices,
+                    target_fps=target_fps,
                 )
             except Exception as metadata_error:
                 logger.warning(f"Failed to capture baseline metadata on interrupt: {metadata_error}")
@@ -505,6 +511,7 @@ def test_dlstreamer(
                     device_list,
                     baseline_streams_results,
                     requested_device_categories=devices,
+                    target_fps=target_fps,
                 )
             except Exception as metadata_error:
                 logger.warning(f"Failed to capture baseline metadata on error: {metadata_error}")


### PR DESCRIPTION
fix: dlstreamer analysis spawns only single container for 2-socket CPU (#829)

* fix: dlstreamer analysis spawns only single container for 2-socket CPU
- chore: enhance multi-socket CPU support and
- chore: add target FPS estimation for stream analysis

* fix: multi-socket max_streams_above_baseline iteration not working properly

* fix: coverity issue
