### PR TITLE
fix: depends-on profiles not triggered when --all flag option is not being used (#834)

### DIFF
--- a/src/esq/configs/system/info/software.yml
+++ b/src/esq/configs/system/info/software.yml
@@ -6,6 +6,7 @@
 # This file defines which packages to track for system information collection
 
 system_packages:
+  - docker-ce
   - ffmpeg
 
 python_packages:

--- a/src/sysagent/cli.py
+++ b/src/sysagent/cli.py
@@ -105,11 +105,12 @@ def main() -> int:
                 filters=args.filter,
                 run_all_profiles=args.all,
                 force=force,
+                no_mask=args.no_mask,
                 extra_args=[],  # No extra args from command line
             )
         elif args.command == "info":
             run_system_info = get_command_function("run_system_info")
-            return run_system_info(verbose=verbose, debug=debug)
+            return run_system_info(verbose=verbose, debug=debug, no_mask=args.no_mask)
         elif args.command == "list":
             list_available_items = get_command_function("list_available_items")
             return list_available_items(verbose=verbose, debug=debug)

--- a/src/sysagent/utils/cli/commands/info.py
+++ b/src/sysagent/utils/cli/commands/info.py
@@ -7,55 +7,62 @@ System information command implementation.
 Handles collecting and displaying comprehensive system information
 including hardware and software details with caching support.
 """
-import os
+
 import logging
+import os
+
 from sysagent.utils.config import setup_data_dir
 from sysagent.utils.logging import setup_command_logging
-from sysagent.utils.system import SystemInfoCache
 
 logger = logging.getLogger(__name__)
 
 
-def run_system_info(verbose: bool = False, debug: bool = False) -> int:
+def run_system_info(verbose: bool = False, debug: bool = False, no_mask: bool = False) -> int:
     """
     Run system information check and display hardware and software details.
-    
+
     The system information cache is always refreshed when this command is run.
-    
+
     Args:
         verbose: Whether to show more detailed output
         debug: Whether to show debug level logs
-        
+        no_mask: Whether to disable masking of data
+
     Returns:
         int: Exit code (0 for success, non-zero for failure)
     """
     try:
+        if no_mask:
+            os.environ["CORE_MASK_DATA"] = "false"
+
+        from sysagent.utils.system import SystemInfoCache
+
         # Setup data directory
         data_dir = setup_data_dir()
-        
+
         # Configure logging with the helper function
         setup_command_logging("info", verbose=verbose, debug=debug, data_dir=data_dir)
-        
+
         # Set data directory in environment for tests to use
         os.environ["CORE_DATA_DIR"] = data_dir
-        
+
         # Initialize system info cache
         logger.debug("Collecting system information...")
         cache_dir = os.path.join(data_dir, "cache")
         system_info_cache = SystemInfoCache(cache_dir)
-        
+
         # Always refresh the cache when info command is run
         logger.debug("Refreshing system information cache")
         system_info_cache.refresh()
-        
+
         logger.debug("System information check completed successfully")
-        
+
         # Generate and display the simple report summary
         report = system_info_cache.generate_simple_report()
         print(report)
-        
+
         return 0
-    
+
     except Exception as e:
         logger.error(f"Error running system information check: {e}", exc_info=debug)
         return 1

--- a/src/sysagent/utils/cli/filters/consolidator.py
+++ b/src/sysagent/utils/cli/filters/consolidator.py
@@ -125,9 +125,6 @@ def _consolidate_direct_parameters(
                         for param_config in test_config["params"]:
                             # Apply filters early if provided
                             if filters and not _match_param_filters(param_config, filters):
-                                logger.debug(
-                                    f"Parameter filtered out for test {test_name}: {param_config.get('test_id', 'unknown')}"
-                                )
                                 continue
 
                             # Merge profile-level parameters

--- a/src/sysagent/utils/cli/parsers.py
+++ b/src/sysagent/utils/cli/parsers.py
@@ -125,6 +125,12 @@ For available profiles, use: {cli_name} list
     run_parser.add_argument(
         "--force", "-f", action="store_true", help="Skip interactive prompts and use default behavior"
     )
+    run_parser.add_argument(
+        "--no-mask",
+        "-nm",
+        action="store_true",
+        help="Disable masking of data (IP addresses, MAC addresses, serial numbers)",
+    )
 
     # System Info command
     info_parser = subparsers.add_parser("info", help="Show system information with hardware and software details")
@@ -132,6 +138,12 @@ For available profiles, use: {cli_name} list
         "--verbose", "-v", action="store_true", help="Display more detailed output with medium traceback"
     )
     info_parser.add_argument("--debug", "-d", action="store_true", help="Display debug output with full traceback")
+    info_parser.add_argument(
+        "--no-mask",
+        "-nm",
+        action="store_true",
+        help="Disable masking of data (IP addresses, MAC addresses, serial numbers)",
+    )
 
     # List command
     list_parser = subparsers.add_parser("list", help="List available profiles and tests")

--- a/src/sysagent/utils/plugins/pytest_validation.py
+++ b/src/sysagent/utils/plugins/pytest_validation.py
@@ -495,8 +495,6 @@ def validate_system_requirements_from_configs():
         else:
             logger.debug("No requirements found in configs")
 
-        logger.info(f"Validating system requirements for test: {test_name}")
-
         if not has_requirements:
             logger.debug("No requirements found to validate")
             with allure.step("Validate system requirements ⚪"):

--- a/src/sysagent/utils/testing/profile_validator.py
+++ b/src/sysagent/utils/testing/profile_validator.py
@@ -10,13 +10,15 @@ converting profile configuration formats to system requirement validation.
 
 import logging
 import os
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 # Setup logger
 logger = logging.getLogger(__name__)
 
 
-def validate_profile_requirements(profile_configs: Dict[str, Any]) -> Dict[str, Any]:
+def validate_profile_requirements(
+    profile_configs: Dict[str, Any], profile_name: Optional[str] = None
+) -> Dict[str, Any]:
     """
     Validate system requirements for a profile using latest system info structure.
 
@@ -25,11 +27,13 @@ def validate_profile_requirements(profile_configs: Dict[str, Any]) -> Dict[str, 
 
     Args:
         profile_configs: Profile configuration dictionary containing requirements
+        profile_name: Optional profile name for better context in validation messages
 
     Returns:
         Dict with validation results containing:
         - passed: bool indicating if all requirements are met
         - checks: list of individual check results
+        - profile_name: profile name if provided
 
     Example:
         profile_configs = {
@@ -42,7 +46,7 @@ def validate_profile_requirements(profile_configs: Dict[str, Any]) -> Dict[str, 
                 }
             }
         }
-        results = validate_profile_requirements(profile_configs)
+        results = validate_profile_requirements(profile_configs, "my-profile")
         if results["passed"]:
             print("All requirements met")
         else:
@@ -64,10 +68,127 @@ def validate_profile_requirements(profile_configs: Dict[str, Any]) -> Dict[str, 
     # Convert profile requirements to system validator format
     system_requirements = _convert_profile_requirements_to_system_format(requirements)
 
-    # Perform validation
-    results = validator.validate_requirements(system_requirements)
+    # Perform validation with profile-specific context
+    context = f"profile: {profile_name}" if profile_name else "system validator"
+    results = validator.validate_requirements(system_requirements, log_suggestions=True, context=context)
+
+    # Add profile name to results for later reference
+    if profile_name:
+        results["profile_name"] = profile_name
 
     return results
+
+
+def validate_filtered_profile_requirements(
+    profile_configs: Dict[str, Any], filters: Optional[Dict[str, Any]] = None, profile_name: Optional[str] = None
+) -> Dict[str, Any]:
+    """
+    Validate system requirements for a profile considering both profile-level and
+    test-specific requirements from filtered test parameters.
+
+    Args:
+        profile_configs: Profile configuration dictionary containing requirements
+        filters: Optional test filters to determine which test parameters to validate
+        profile_name: Optional profile name for better context in validation messages
+
+    Returns:
+        Dict with validation results containing:
+        - passed: bool indicating if all requirements are met
+        - checks: list of individual check results
+        - profile_checks: list of profile-level requirement checks
+        - test_checks: list of test-specific requirement checks
+    """
+    from sysagent.utils.cli.filters.consolidator import consolidate_profile_parameters
+    from sysagent.utils.config import setup_data_dir
+    from sysagent.utils.testing.system_validator import SystemValidator
+
+    logger.debug("Validating requirements for profile with filtered tests")
+
+    data_dir = setup_data_dir()
+    cache_dir = os.path.join(data_dir, "cache")
+    validator = SystemValidator(cache_dir)
+
+    # Validate profile-level requirements
+    profile_params = profile_configs.get("params", {})
+    profile_requirements = profile_params.get("requirements", {})
+    profile_system_requirements = _convert_profile_requirements_to_system_format(profile_requirements)
+
+    # Don't log suggestions here - will be consolidated below
+    profile_results = validator.validate_requirements(profile_system_requirements, log_suggestions=False)
+
+    # Get consolidated test parameters that would actually run based on filters
+    try:
+        consolidated_params = consolidate_profile_parameters(profile_configs, filters)
+        logger.debug(f"Found {len(consolidated_params)} test parameters after filtering")
+    except Exception as e:
+        logger.warning(f"Could not consolidate profile parameters: {e}")
+        consolidated_params = []
+
+    # Collect all unique test-specific requirements
+    all_test_requirements = {}
+    test_requirements_list = []
+
+    for param in consolidated_params:
+        test_requirements = param.get("param", {}).get("requirements", {})
+        if test_requirements:
+            test_id = param.get("param", {}).get("test_id", "unknown")
+            logger.debug(f"Test {test_id} has requirements: {list(test_requirements.keys())}")
+
+            # Merge test requirements into combined set
+            for key, value in test_requirements.items():
+                if key not in all_test_requirements:
+                    all_test_requirements[key] = value
+                    test_requirements_list.append((test_id, key, value))
+                elif all_test_requirements[key] != value:
+                    # If different tests have conflicting requirements, use most restrictive
+                    logger.debug(f"Conflicting requirement {key}: {all_test_requirements[key]} vs {value}")
+                    if isinstance(value, (int, float)) and isinstance(all_test_requirements[key], (int, float)):
+                        all_test_requirements[key] = max(all_test_requirements[key], value)
+
+    # Validate test-specific requirements if any exist
+    test_results = {"passed": True, "checks": []}
+    if all_test_requirements:
+        test_system_requirements = _convert_profile_requirements_to_system_format(all_test_requirements)
+        test_results = validator.validate_requirements(test_system_requirements, log_suggestions=False)
+
+        # Add context to test requirement checks
+        for check in test_results.get("checks", []):
+            check["context"] = "test-specific"
+    else:
+        logger.info("No test-specific requirements found in filtered parameters")
+
+    # Add context to profile requirement checks
+    for check in profile_results.get("checks", []):
+        check["context"] = "profile-level"
+
+    # Combine results
+    all_checks = profile_results.get("checks", []) + test_results.get("checks", [])
+    overall_passed = profile_results.get("passed", False) and test_results.get("passed", False)
+
+    combined_results = {
+        "passed": overall_passed,
+        "checks": all_checks,
+        "profile_checks": profile_results.get("checks", []),
+        "test_checks": test_results.get("checks", []),
+        "profile_passed": profile_results.get("passed", False),
+        "test_passed": test_results.get("passed", False),
+    }
+
+    # Log summary with profile context
+    if not overall_passed:
+        failed_checks = [check for check in all_checks if not check.get("passed", False)]
+
+        # Provide consolidated fix suggestions without duplicates, with profile context
+        from sysagent.utils.testing.validation_suggestions import log_validation_fix_suggestions
+
+        context = f"profile: {profile_name}" if profile_name else "system validator"
+        log_validation_fix_suggestions(failed_checks, context=context, deduplicate_by_category=True)
+
+    # Add profile name to results for later reference
+    if profile_name:
+        combined_results["profile_name"] = profile_name
+
+    return combined_results
 
 
 def _convert_profile_requirements_to_system_format(
@@ -102,12 +223,12 @@ def _convert_profile_requirements_to_system_format(
                 system_format["hardware"][cpu_field] = profile_requirements[cpu_field]
 
         # Memory requirements - direct mapping
-        for memory_field in ["memory_min_gb"]:
+        for memory_field in ["memory_min_gb", "memory_total_min_gb"]:
             if memory_field in profile_requirements:
                 system_format["hardware"][memory_field] = profile_requirements[memory_field]
 
         # Storage requirements - direct mapping
-        for storage_field in ["storage_min_gb"]:
+        for storage_field in ["storage_min_gb", "storage_total_min_gb"]:
             if storage_field in profile_requirements:
                 system_format["hardware"][storage_field] = profile_requirements[storage_field]
 

--- a/src/sysagent/utils/testing/tier_validator.py
+++ b/src/sysagent/utils/testing/tier_validator.py
@@ -80,7 +80,8 @@ def _validate_tiers(
             )
             continue
         merged_req = _merge_requirements(tier_obj, profile_reqs, test_reqs, use_profile_reqs)
-        result = validator.validate_requirements({"hardware": merged_req, "software": {}})
+        # Don't log suggestions for tier validation - tier mismatches are expected and handled internally
+        result = validator.validate_requirements({"hardware": merged_req, "software": {}}, log_suggestions=False)
         results.append(
             {
                 "tier": tier_name,

--- a/src/sysagent/utils/testing/validation_suggestions.py
+++ b/src/sysagent/utils/testing/validation_suggestions.py
@@ -1,0 +1,181 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Shared validation suggestion utilities.
+
+This module provides shared functions for generating user-friendly fix suggestions
+for failed system requirements across different validation contexts.
+"""
+
+import logging
+from typing import Any, Dict, List
+
+logger = logging.getLogger(__name__)
+
+
+def log_validation_fix_suggestions(
+    failed_checks: List[Dict[str, Any]], context: str = "validation", deduplicate_by_category: bool = False
+) -> None:
+    """
+    Log user-friendly suggestions for fixing failed system requirements.
+
+    Args:
+        failed_checks: List of failed check dictionaries containing name, category, etc.
+        context: Context string to include in the header message (e.g., "profile: my-profile")
+        deduplicate_by_category: Whether to deduplicate suggestions by category to avoid duplicates
+    """
+    if not failed_checks:
+        return
+
+    # Handle deduplication if requested
+    checks_to_process = failed_checks
+    if deduplicate_by_category:
+        checks_to_process = _deduplicate_checks_by_category(failed_checks)
+
+    # Format header based on context type
+    if context.startswith("profile:"):
+        profile_name = context.split(":", 1)[1].strip()
+        logger.info("")
+        logger.info(f"╭─ Validation Failed: {profile_name}")
+        logger.info(f"│  Missing requirements ({len(checks_to_process)}):")
+    else:
+        logger.info("")
+        logger.info(f"Missing requirements ({context}):")
+
+    for check in checks_to_process:
+        category = check.get("category", "")
+        name = check["name"]
+
+        _log_single_suggestion(category, name, check, is_in_profile_context=context.startswith("profile:"))
+
+    # Add bottom border for profile context
+    if context.startswith("profile:"):
+        logger.info("╰─")
+
+
+def _deduplicate_checks_by_category(failed_checks: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """
+    Remove duplicate suggestions based on category to avoid redundant messages.
+
+    Args:
+        failed_checks: List of failed check dictionaries
+
+    Returns:
+        List of unique checks based on category
+    """
+    seen_categories = set()
+    unique_checks = []
+
+    for check in failed_checks:
+        category = check.get("category", "")
+
+        if category not in seen_categories:
+            seen_categories.add(category)
+            unique_checks.append(check)
+
+    return unique_checks
+
+
+def _log_single_suggestion(
+    category: str, name: str, check: Dict[str, Any], is_in_profile_context: bool = False
+) -> None:
+    """
+    Log a single fix suggestion based on the requirement category.
+
+    Args:
+        category: Category string (e.g., "software.docker.required")
+        name: Human-readable name of the requirement
+        check: Full check dictionary for additional context
+        is_in_profile_context: Whether this is being logged within a profile validation context
+    """
+    # Use different prefix based on context
+    prefix = "│  " if is_in_profile_context else ""
+    if category == "software.docker.required":
+        logger.info(f"{prefix}• {name}: Refer to Docker official installation guide")
+        logger.info(f"{prefix}  Then add user to docker group: 'sudo usermod -aG docker $USER && newgrp docker'")
+    elif category == "hardware.gpu.discrete":
+        logger.info(f"{prefix}• {name}: This test requires a discrete GPU (dGPU). Check if:")
+        logger.info(f"{prefix}  - A discrete GPU is properly installed and seated")
+        logger.info(f"{prefix}  - GPU drivers are installed (Intel Arc, AMD, or NVIDIA)")
+        logger.info(f"{prefix}  - GPU is detected by the system (check with 'lspci | grep -i vga')")
+    elif category == "hardware.gpu.integrated":
+        logger.info(f"{prefix}• {name}: This test requires an integrated GPU (iGPU). Check if:")
+        logger.info(f"{prefix}  - Integrated graphics are enabled in BIOS/UEFI")
+        logger.info(f"{prefix}  - Intel graphics drivers are installed")
+        logger.info(f"{prefix}  - CPU supports integrated graphics")
+    elif category == "hardware.cpu.cores":
+        logger.info(f"{prefix}• {name}: Upgrade to a CPU with more cores")
+    elif category == "hardware.memory.available":
+        logger.info(f"{prefix}• {name}: Free up system memory by closing applications or add more RAM")
+    elif category == "hardware.memory.total":
+        logger.info(f"{prefix}• {name}: Add more system RAM to meet total memory requirements")
+    elif category == "hardware.storage.free":
+        logger.info(f"{prefix}• {name}: Free up disk space or add more storage")
+    elif category == "hardware.storage.total":
+        logger.info(f"{prefix}• {name}: Upgrade to larger storage capacity")
+    elif category == "software.os.type":
+        logger.info(f"{prefix}• {name}: This test requires a different operating system")
+    elif category == "software.python.version":
+        logger.info(f"{prefix}• {name}: Upgrade Python version")
+    elif "system_packages" in category:
+        logger.info(f"{prefix}• {name}: Ensure dependency is installed")
+    elif "python_packages" in category:
+        logger.info(f"{prefix}• {name}: Ensure dependency is installed")
+    else:
+        logger.info(f"{prefix}• {name}: Check system documentation for {check['required']}")
+
+
+def get_fix_suggestion_for_category(category: str, name: str, check: Dict[str, Any]) -> List[str]:
+    """
+    Get fix suggestions for a specific category as a list of strings (for testing or other uses).
+
+    Args:
+        category: Category string (e.g., "software.docker.required")
+        name: Human-readable name of the requirement
+        check: Full check dictionary for additional context
+
+    Returns:
+        List of suggestion strings
+    """
+    suggestions = []
+
+    if category == "software.docker.required":
+        suggestions.append(
+            f"{name}: Install Docker with 'sudo apt install docker.io' or 'curl -fsSL https://get.docker.com | sh'"
+        )
+        suggestions.append("Then add user to docker group: 'sudo usermod -aG docker $USER && newgrp docker'")
+    elif category == "hardware.gpu.discrete":
+        suggestions.append(f"{name}: This test requires a discrete GPU (dGPU). Check if:")
+        suggestions.append("- A discrete GPU is properly installed and seated")
+        suggestions.append("- GPU drivers are installed (Intel Arc, AMD, or NVIDIA)")
+        suggestions.append("- GPU is detected by the system (check with 'lspci | grep -i vga')")
+    elif category == "hardware.gpu.integrated":
+        suggestions.append(f"{name}: This test requires an integrated GPU (iGPU). Check if:")
+        suggestions.append("- Integrated graphics are enabled in BIOS/UEFI")
+        suggestions.append("- Intel graphics drivers are installed")
+        suggestions.append("- CPU supports integrated graphics")
+    elif category == "hardware.cpu.cores":
+        suggestions.append(f"{name}: Upgrade to a CPU with more cores, or use a different test profile")
+    elif category == "hardware.memory.available":
+        suggestions.append(f"{name}: Free up system memory by closing applications or add more RAM")
+    elif category == "hardware.memory.total":
+        suggestions.append(f"{name}: Add more system RAM to meet total memory requirements")
+    elif category == "hardware.storage.free":
+        suggestions.append(f"{name}: Free up disk space or add more storage")
+    elif category == "hardware.storage.total":
+        suggestions.append(f"{name}: Upgrade to larger storage capacity")
+    elif category == "software.os.type":
+        suggestions.append(f"{name}: This test requires a different operating system")
+    elif category == "software.python.version":
+        suggestions.append(f"{name}: Upgrade Python with 'sudo apt install python3' or use pyenv/conda")
+    elif "system_packages" in category:
+        package = name.split("'")[1] if "'" in name else "unknown"
+        suggestions.append(f"{name}: Install with 'sudo apt install {package}' (Ubuntu/Debian)")
+    elif "python_packages" in category:
+        package = name.split("'")[1] if "'" in name else "unknown"
+        suggestions.append(f"{name}: Install with 'pip install {package}' or 'uv pip install {package}'")
+    else:
+        suggestions.append(f"{name}: Check system documentation for {check['required']}")
+
+    return suggestions


### PR DESCRIPTION
fix: depends-on profiles not triggered when --all flag option is not being used (#834)

* fix: depends-on profiles not running when --all flag option is not being used
- chore: update prompt to include additional info and list of vertical profiles

* chore: enable masking of extracted system info data by default

* chore: update cli prompt message options

* chore: remove app name and version to avoid dynamic versioning in CLI output

* feat: enhance profile validation and system requirement checks before run

* chore: exclude unnecesarry system requirements check logs
