### PR TITLE
fix: vision ai pipeline missing starting frame element and update pipeline with fakesink sync=true (#837)

### DIFF
--- a/src/esq/configs/profiles/qualifications/ai_edge_system.yml
+++ b/src/esq/configs/profiles/qualifications/ai_edge_system.yml
@@ -118,13 +118,15 @@ params:
         FULL_DEVICE_NAME:
           "Intel(R) Unsupported video type": "'video/x-raw'"
     BATCH_SIZE:
-      cpu: "8"
+      cpu: "1"
       gpu_integrated: "8"
       gpu_discrete: "8"
       gpu_discrete_primary: "8"
       npu: "1"
     SYNC:
-      default: "false"
+      default: "true"
+    FPSCOUNTER_PROPS:
+      default: "starting-frame=2000"
 
 suites:
   - name: "ai"

--- a/src/esq/configs/profiles/suites/ai_vision.yml
+++ b/src/esq/configs/profiles/suites/ai_vision.yml
@@ -107,13 +107,15 @@ params:
         FULL_DEVICE_NAME:
           "Intel(R) Unsupported video type": "'video/x-raw'"
     BATCH_SIZE:
-      cpu: "8"
+      cpu: "1"
       gpu_integrated: "8"
       gpu_discrete: "8"
       gpu_discrete_primary: "8"
       npu: "1"
     SYNC:
-      default: "false"
+      default: "true"
+    FPSCOUNTER_PROPS:
+      default: "starting-frame=2000"
 
 suites:
   - name: "ai"

--- a/src/esq/suites/ai/vision/config.yml
+++ b/src/esq/suites/ai/vision/config.yml
@@ -12,7 +12,7 @@ kpi:
     unit: "streams"
     severity: "normal"
     description: "Maximum number of concurrent video streams"
-    default_value: -1.0
+    default_value: 0.0
 
   streams_max_cpu:
     name: "Maximum Streams CPU"
@@ -24,7 +24,7 @@ kpi:
     unit: "streams"
     severity: "normal"
     description: "Maximum number of concurrent video streams on CPU"
-    default_value: -1.0
+    default_value: 0.0
 
   streams_max_igpu:
     name: "Maximum Streams iGPU"
@@ -36,7 +36,7 @@ kpi:
     unit: "streams"
     severity: "normal"
     description: "Maximum number of concurrent video streams on iGPU"
-    default_value: -1.0
+    default_value: 0.0
 
   streams_max_dgpu:
     name: "Maximum Streams dGPU"
@@ -48,7 +48,7 @@ kpi:
     unit: "streams"
     severity: "normal"
     description: "Maximum number of concurrent video streams on dGPU"
-    default_value: -1.0
+    default_value: 0.0
 
   streams_max_npu:
     name: "Maximum Streams NPU"
@@ -60,7 +60,7 @@ kpi:
     unit: "streams"
     severity: "normal"
     description: "Maximum number of concurrent video streams on NPU"
-    default_value: -1.0
+    default_value: 0.0
 
 tests:
   test_dlstreamer:


### PR DESCRIPTION
fix: vision ai pipeline missing starting frame element and update pipeline with fakesink sync=true (#837)

* fix: vision ai pipeline missing starting frame element

* fix: baseline analysis of vision ai pipeline with sync=true failed due to timeout error

* chore: update multi-stream analysis of vision ai pipeline to use fakesink sync=true

* chore: update optimize cpu batch size for fakesink sync=true

* fix: default streams metric value is showing as -1 instead of 0
