### PR TITLE
feat: enable configurable consecutive timeout threshold for DL Streamer pipeline (#859)

### DIFF
--- a/src/esq/suites/ai/vision/config.yml
+++ b/src/esq/suites/ai/vision/config.yml
@@ -123,6 +123,10 @@ tests:
             url: "https://raw.githubusercontent.com/open-edge-platform/edge-ai-libraries/main/libraries/dl-streamer/samples/labels/imagenet_2012.txt"
             sha256: "acf75ef0abe89694b19056e0796401068b459c457baa30335f240c7692857355"
             path: "./labels/imagenet_2012.txt"
+        # Consecutive threshold parameters for intelligent binary search qualification
+        # consecutive_success_threshold: 1  # Number of consecutive successes before trying higher streams
+        # consecutive_failure_threshold: 2  # Number of consecutive FPS-based failures (>0 FPS but below target) before trying lower streams
+        # consecutive_timeout_threshold: 2  # Number of consecutive timeout failures (below baseline only) before trying lower streams
         pipeline: |
           filesrc location=./videos/1192116-hd_1920_1080_15fps_30s.mp4
             ! ${DECODE_ELEMENTS}

--- a/src/esq/suites/ai/vision/src/dlstreamer/execution.py
+++ b/src/esq/suites/ai/vision/src/dlstreamer/execution.py
@@ -33,6 +33,7 @@ def run_device_test(
     num_sockets: int,
     consecutive_success_threshold: int,
     consecutive_failure_threshold: int,
+    consecutive_timeout_threshold: int,
     max_streams_above_baseline: int,
     qualified_devices: Dict[str, Any],
     metrics=None,
@@ -106,6 +107,7 @@ def run_device_test(
             num_sockets=num_sockets,
             consecutive_success_threshold=consecutive_success_threshold,
             consecutive_failure_threshold=consecutive_failure_threshold,
+            consecutive_timeout_threshold=consecutive_timeout_threshold,
             max_streams_above_baseline=max_streams_above_baseline,
             container_config=container_config,
         )

--- a/src/esq/suites/ai/vision/test_dlstreamer.py
+++ b/src/esq/suites/ai/vision/test_dlstreamer.py
@@ -75,6 +75,7 @@ def test_dlstreamer(
     docker_container_prefix = configs.get("docker_container_prefix", "test-dlstreamer")
     consecutive_success_threshold = configs.get("consecutive_success_threshold", 1)
     consecutive_failure_threshold = configs.get("consecutive_failure_threshold", 2)
+    consecutive_timeout_threshold = configs.get("consecutive_timeout_threshold", 2)
     max_streams_above_baseline = configs.get("max_streams_above_baseline", 3)
 
     # Setup
@@ -353,6 +354,7 @@ def test_dlstreamer(
                     num_sockets=num_sockets,
                     consecutive_success_threshold=consecutive_success_threshold,
                     consecutive_failure_threshold=consecutive_failure_threshold,
+                    consecutive_timeout_threshold=consecutive_timeout_threshold,
                     max_streams_above_baseline=max_streams_above_baseline,
                     qualified_devices=qualified_devices,
                     metrics=default_metrics,


### PR DESCRIPTION
feat: enable configurable consecutive timeout threshold for DL Streamer pipeline (#859)
