### PR TITLE
fix: update Vision AI qualification pipeline with new video assets (#847)

### DIFF
--- a/src/esq/configs/profiles/qualifications/ai_edge_system.yml
+++ b/src/esq/configs/profiles/qualifications/ai_edge_system.yml
@@ -33,16 +33,6 @@ params:
     docker_required: true
   # Vision AI global params
   assets:
-    - id: "video_18856748"
-      type: "video"
-      name: "18856748-bears_1920_1080_30fps_30s.h265"
-      url: "https://videos.pexels.com/video-files/18856748/18856748-uhd_3840_2160_60fps.mp4"
-      sha256: "2bcbd55f8ab8f34cbce33af0a7f372c2d4648b4386249728ba4c6cd51e8d7985"
-      width: 1920
-      height: 1080
-      fps: 30
-      codec: "h265"
-      loop: 30 # Loop to achieve ~30s duration
     - id: "yolo11n"
       type: "model"
       source: "ultralytics"
@@ -51,60 +41,70 @@ params:
       export_args:
         dynamic: true
         half: true
-    - id: "resnet-50"
+    - id: "video_6891009"
+      type: "video"
+      name: "6891009-apple_1080p15.mp4"
+      url: "https://www.pexels.com/download/video/6891009"
+      sha256: "b30010389562c03a15dad0d5eaa34334bb58b28214f280815e22abddcb1dffb4"
+      width: 1920
+      height: 1080
+      fps: 15
+      codec: "h264"
+    - id: "efficientnet_b0"
       type: "model"
-      source: "kagglehub"
-      precision: "int8"
+      source: "files"
+      url: 
+        - xml: "https://raw.githubusercontent.com/dlstreamer/pipeline-zoo-models/ee73878abc6fb6d864e59a5cd80016de4fc1d194/storage/efficientnet-b0_INT8/FP16-INT8/efficientnet-b0.xml"
+        - bin: "https://raw.githubusercontent.com/dlstreamer/pipeline-zoo-models/ee73878abc6fb6d864e59a5cd80016de4fc1d194/storage/efficientnet-b0_INT8/FP16-INT8/efficientnet-b0.bin"
+      sha256:
+        - xml: "e9f959bb05ea1dc4d4735acc62e3d959fa2982b82e9608325157ba3598b5b999"
+        - bin: "2ee5a5ad5a9a1a00d057e50af5da56e3bf09f633f66e9f77b9a1915ab862c536"
+      precision: "int8"  # exported model precision metadata
       format: "openvino"
-      kaggle_handle: "google/resnet-v1/tensorFlow2/50-classification"
-      convert_args:
-        input_shape: [1, 224, 224, 3]
-        input_layout: "NHWC"
-        tensor_layout: "NCHW"
-      quantize_args:
-        calibration_samples: 512
-        calibration_dataset: "cifar100"
-    - id: "resnet-50-optimized-model-proc"
+    # File assets
+    - id: "imagenet_2012.txt"
       type: "file"
-      url: "https://raw.githubusercontent.com/open-edge-platform/edge-ai-libraries/14bc74481d4535ee45848a7e5ad54f85754e0576/libraries/dl-streamer/samples/gstreamer/model_proc/public/classification-optimized.json"
-      sha256: "27195581b907f35669ff7a127a7a6c3d0779e2c8240c889e0e7441c1c6f4a5ce"
-      path: "./models/resnet-50/resnet-50-optimized.json"
-  target_fps: 28.5
+      url: "https://raw.githubusercontent.com/open-edge-platform/edge-ai-libraries/3d2c76dcbc5b0f4aa0ac11d77873427c4c86fb22/libraries/dl-streamer/samples/labels/imagenet_2012.txt"
+      sha256: "acf75ef0abe89694b19056e0796401068b459c457baa30335f240c7692857355"
+      path: "./labels/imagenet_2012.txt"
+    - id: "preproc-aspect-ratio.json"
+      type: "file"
+      url: "https://raw.githubusercontent.com/open-edge-platform/edge-ai-libraries/3d2c76dcbc5b0f4aa0ac11d77873427c4c86fb22/libraries/dl-streamer/samples/gstreamer/model_proc/public/preproc-aspect-ratio.json"
+      sha256: "824db3e19e1e0a71caba8370606413b2bcd0d9339fb4c5b9535d4c3f2091095a"
+      path: "./labels/preproc-aspect-ratio.json"
+  target_fps: 14.95
+  consecutive_timeout_threshold: 2 
   pipeline: |
-    filesrc location=./videos/18856748-bears_1920_1080_30fps_30s.h265
+    filesrc location=./videos/6891009-apple_1080p15.mp4
       ! ${DECODE_ELEMENTS}
       ! queue
-      ! gvadetect model=./models/yolo11n/int8/dynamic_half/yolo11n.xml 
-          device=${DEVICE_ID}
-          ${INFERENCE_ELEMENTS}
-          batch-size=${BATCH_SIZE}
-          inference-interval=3 
+      ! gvadetect batch-size=${BATCH_SIZE} model-instance-id=detection model=./models/yolo11n/int8/dynamic_half/yolo11n.xml 
           threshold=0.5
-          model-instance-id=yolov11n
-      ! queue
-      ! gvatrack tracking-type=1 config=tracking_per_class=false
-      ! queue 
-      ! gvaclassify model=./models/resnet-50/int8/resnet-50.xml
-          model-proc=./models/resnet-50/resnet-50-optimized.json
           device=${DEVICE_ID}
           ${INFERENCE_ELEMENTS}
-          batch-size=${BATCH_SIZE}
-          inference-interval=3 
-          inference-region=1
-          model-instance-id=resnet50 
+      ! queue
+      ! gvatrack tracking-type=zero-term-imageless
+      ! queue 
+      ! gvaclassify batch-size=${BATCH_SIZE} model-instance-id=classifier
+          labels=./labels/imagenet_2012.txt
+          model=./models/efficientnet_b0/int8/efficientnet-b0.xml
+          model-proc=./labels/preproc-aspect-ratio.json
+          device=${DEVICE_ID}
+          ${INFERENCE_ELEMENTS}
+          reclassify-interval=1
       ! queue
   pipeline_params:
     DECODE_ELEMENTS:
-      cpu: "h265parse ! avdec_h265 ! capsfilter caps='video/x-raw'"
-      gpu_integrated: "h265parse ! vah265dec ! capsfilter caps='video/x-raw(memory:VAMemory)'"
-      gpu_discrete: "h265parse ! varenderD{RENDER_DEVICE_NUM}h265dec ! capsfilter caps='video/x-raw(memory:VAMemory)'"
-      gpu_discrete_primary: "h265parse ! vah265dec ! capsfilter caps='video/x-raw(memory:VAMemory)'"
-      npu: "h265parse ! vah265dec ! capsfilter caps='video/x-raw(memory:VAMemory)'"
+      cpu: "qtdemux ! h264parse ! avdec_h264 ! video/x-raw"
+      gpu_integrated: "qtdemux ! h264parse ! vah264dec ! vapostproc ! capsfilter caps='video/x-raw(memory:VAMemory)'"
+      gpu_discrete: "qtdemux ! h264parse ! varenderD{RENDER_DEVICE_NUM}h264dec ! capsfilter caps='video/x-raw(memory:VAMemory)'"
+      gpu_discrete_primary: "qtdemux ! h264parse ! vah264dec ! capsfilter caps='video/x-raw(memory:VAMemory)'"
+      npu: "qtdemux ! h264parse ! vah264dec ! capsfilter caps='video/x-raw(memory:VAMemory)'"
     INFERENCE_ELEMENTS:
-      cpu: "pre-process-backend={PRE_PROCESS_BACKEND} nireq=2 ie-config=NUM_STREAMS=2"
-      gpu_integrated: "pre-process-backend={PRE_PROCESS_BACKEND} nireq=2 ie-config=NUM_STREAMS=2"
-      gpu_discrete: "pre-process-backend={PRE_PROCESS_BACKEND} nireq=2 ie-config=NUM_STREAMS=2"
-      gpu_discrete_primary: "pre-process-backend={PRE_PROCESS_BACKEND} nireq=2 ie-config=NUM_STREAMS=2"
+      cpu: "pre-process-backend={PRE_PROCESS_BACKEND} ie-config=CPU_THROUGHPUT_STREAMS=2 nireq=2"
+      gpu_integrated: "pre-process-backend={PRE_PROCESS_BACKEND} ie-config=GPU_THROUGHPUT_STREAMS=2 nireq=2 "
+      gpu_discrete: "pre-process-backend={PRE_PROCESS_BACKEND} ie-config=GPU_THROUGHPUT_STREAMS=2 nireq=2 "
+      gpu_discrete_primary: "pre-process-backend={PRE_PROCESS_BACKEND} ie-config=GPU_THROUGHPUT_STREAMS=2 nireq=2 "
       npu: "pre-process-backend={PRE_PROCESS_BACKEND} nireq=4"
     PRE_PROCESS_BACKEND:
       cpu: "opencv"
@@ -118,15 +118,15 @@ params:
         FULL_DEVICE_NAME:
           "Intel(R) Unsupported video type": "'video/x-raw'"
     BATCH_SIZE:
-      cpu: "1"
+      cpu: "8"
       gpu_integrated: "8"
       gpu_discrete: "8"
       gpu_discrete_primary: "8"
       npu: "1"
     SINK_ELEMENT:
-      default: "fakesink sync=true"
+      default: "fakesink sync=false async=false"
     FPSCOUNTER_PROPS:
-      default: "starting-frame=2000"
+      default: ""    
 
 suites:
   - name: "ai"
@@ -350,7 +350,7 @@ suites:
             params:
               # Entry
               - test_id: "AES-VSN-001"
-                display_name: "Vision AI Benchmark - multi-stream 1080p30 H.265 gvadetect YOLO11n INT8 gvatrack gvaclassify ResNet50 INT8"
+                display_name: "Vision AI Analysis - multi-stream 1080p15 H.264 gvadetect YOLO11n INT8 gvatrack gvaclassify EfficientNet-B0 INT8"
                 devices: [cpu, igpu, dgpu, npu]
                 tiers:
                   - entry
@@ -364,7 +364,7 @@ suites:
 
               # Mainstream
               - test_id: "AES-VSN-001"
-                display_name: "Vision AI Benchmark - multi-stream 1080p30 H.265 gvadetect YOLO11n INT8 gvatrack gvaclassify ResNet50 INT8"
+                display_name: "Vision AI Analysis - multi-stream 1080p15 H.264 gvadetect YOLO11n INT8 gvatrack gvaclassify EfficientNet-B0 INT8"
                 devices: [cpu, igpu, dgpu, npu]
                 tiers:
                   - mainstream
@@ -378,7 +378,7 @@ suites:
 
               # Efficiency Optimized
               - test_id: "AES-VSN-001"
-                display_name: "Vision AI Benchmark - multi-stream 1080p30 H.265 gvadetect YOLO11n INT8 gvatrack gvaclassify ResNet50 INT8"
+                display_name: "Vision AI Analysis - multi-stream 1080p15 H.264 gvadetect YOLO11n INT8 gvatrack gvaclassify EfficientNet-B0 INT8"
                 devices: [cpu, igpu, dgpu, npu]
                 tiers:
                   - efficiency_optimized
@@ -392,7 +392,7 @@ suites:
 
               # Scalable Performance
               - test_id: "AES-VSN-001"
-                display_name: "Vision AI Benchmark - multi-stream 1080p30 H.265 gvadetect YOLO11n INT8 gvatrack gvaclassify ResNet50 INT8"
+                display_name: "Vision AI Analysis - multi-stream 1080p15 H.264 gvadetect YOLO11n INT8 gvatrack gvaclassify EfficientNet-B0 INT8"
                 devices: [cpu, igpu, dgpu, npu]
                 tiers:
                   - scalable_performance
@@ -406,7 +406,7 @@ suites:
 
               # Scalable AI Graphic Media
               - test_id: "AES-VSN-001"
-                display_name: "Vision AI Benchmark - multi-stream 1080p30 H.265 gvadetect YOLO11n INT8 gvatrack gvaclassify ResNet50 INT8"
+                display_name: "Vision AI Analysis - multi-stream 1080p15 H.264 gvadetect YOLO11n INT8 gvatrack gvaclassify EfficientNet-B0 INT8"
                 devices: [cpu, igpu, dgpu, npu]
                 tiers:
                   # dGPU based specific tiers

--- a/src/esq/configs/profiles/suites/ai_vision_light.yml
+++ b/src/esq/configs/profiles/suites/ai_vision_light.yml
@@ -2,8 +2,8 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-name: "profile.suite.ai.vision"
-description: "Vision AI suite profile"
+name: "profile.suite.ai.vision-light"
+description: "Vision AI suite profile - Light"
 version: "1.0.0"
 params:
   labels:
@@ -125,28 +125,29 @@ suites:
         tests:
           test_dlstreamer:
             params:
-              - test_id: "VSN-DLS-001"
-                display_name: "DL Streamer Benchmark - multi-stream 1080p30 H.265 gvadetect YOLO11n INT8 gvatrack gvaclassify ResNet50 INT8"
+              - test_id: "VSN-LGT-001"
+                display_name: "DL Streamer Analysis - multi-stream 1080p30 H.265 gvadetect YOLO11n INT8 gvatrack gvaclassify ResNet50 INT8"
                 devices: [cpu, igpu, dgpu, npu]
 
-              - test_id: "VSN-DLS-002"
-                display_name: "DL Streamer Benchmark - multi-stream 1080p30 H.265 gvadetect YOLO11n INT8 gvatrack gvaclassify ResNet50 INT8 (CPU)"
+              - test_id: "VSN-LGT-002"
+                display_name: "DL Streamer Analysis - multi-stream 1080p30 H.265 gvadetect YOLO11n INT8 gvatrack gvaclassify ResNet50 INT8 (CPU)"
                 devices: [cpu]
 
-              - test_id: "VSN-DLS-003"
-                display_name: "DL Streamer Benchmark - multi-stream 1080p30 H.265 gvadetect YOLO11n INT8 gvatrack gvaclassify ResNet50 INT8 (iGPU)"
+              - test_id: "VSN-LGT-003"
+                display_name: "DL Streamer Analysis - multi-stream 1080p30 H.265 gvadetect YOLO11n INT8 gvatrack gvaclassify ResNet50 INT8 (iGPU)"
                 devices: [igpu]
                 requirements:
                   igpu_required: true
 
-              - test_id: "VSN-DLS-004"
-                display_name: "DL Streamer Benchmark - multi-stream 1080p30 H.265 gvadetect YOLO11n INT8 gvatrack gvaclassify ResNet50 INT8 (dGPU)"
+              - test_id: "VSN-LGT-004"
+                display_name: "DL Streamer Analysis - multi-stream 1080p30 H.265 gvadetect YOLO11n INT8 gvatrack gvaclassify ResNet50 INT8 (dGPU)"
                 devices: [dgpu]
                 requirements:
                   dgpu_required: true
 
-              - test_id: "VSN-DLS-005"
-                display_name: "DL Streamer Benchmark - multi-stream 1080p30 H.265 gvadetect YOLO11n INT8 gvatrack gvaclassify ResNet50 INT8 (NPU)"
+              - test_id: "VSN-LGT-005"
+                display_name: "DL Streamer Analysis - multi-stream 1080p30 H.265 gvadetect YOLO11n INT8 gvatrack gvaclassify ResNet50 INT8 (NPU)"
                 devices: [npu]
                 requirements:
                   npu_required: true
+            

--- a/src/esq/configs/profiles/suites/ai_vision_vrb.yml
+++ b/src/esq/configs/profiles/suites/ai_vision_vrb.yml
@@ -1,0 +1,153 @@
+
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+name: "profile.suite.ai.vision-vrb"
+description: "Vision AI suite profile - Verified Reference Blueprints"
+version: "1.0.0"
+params:
+  labels:
+    profile_display_name: "Vision AI"
+    group: "ai.vision"
+    type: "suite"
+    display_status: false
+  requirements:
+    # Hardware requirements
+    cpu_min_cores: 2
+    memory_min_gb: 5.0
+    storage_total_min_gb: 64.0
+    storage_min_gb: 10.0  # Free storage for test execution
+    # Software requirements
+    os_type:
+      - "linux"
+    docker_required: true
+  assets:
+    - id: "yolo11n"
+      type: "model"
+      source: "ultralytics"
+      precision: "int8"
+      format: "pt"
+      export_args:
+        dynamic: true
+        half: true
+    - id: "video_6891009"
+      type: "video"
+      name: "6891009-apple_1080p15.mp4"
+      url: "https://www.pexels.com/download/video/6891009"
+      sha256: "b30010389562c03a15dad0d5eaa34334bb58b28214f280815e22abddcb1dffb4"
+      width: 1920
+      height: 1080
+      fps: 15
+      codec: "h264"
+    - id: "efficientnet_b0"
+      type: "model"
+      source: "files"
+      url: 
+        - xml: "https://raw.githubusercontent.com/dlstreamer/pipeline-zoo-models/ee73878abc6fb6d864e59a5cd80016de4fc1d194/storage/efficientnet-b0_INT8/FP16-INT8/efficientnet-b0.xml"
+        - bin: "https://raw.githubusercontent.com/dlstreamer/pipeline-zoo-models/ee73878abc6fb6d864e59a5cd80016de4fc1d194/storage/efficientnet-b0_INT8/FP16-INT8/efficientnet-b0.bin"
+      sha256:
+        - xml: "e9f959bb05ea1dc4d4735acc62e3d959fa2982b82e9608325157ba3598b5b999"
+        - bin: "2ee5a5ad5a9a1a00d057e50af5da56e3bf09f633f66e9f77b9a1915ab862c536"
+      precision: "int8"  # exported model precision metadata
+      format: "openvino"
+    # File assets
+    - id: "imagenet_2012.txt"
+      type: "file"
+      url: "https://raw.githubusercontent.com/open-edge-platform/edge-ai-libraries/3d2c76dcbc5b0f4aa0ac11d77873427c4c86fb22/libraries/dl-streamer/samples/labels/imagenet_2012.txt"
+      sha256: "acf75ef0abe89694b19056e0796401068b459c457baa30335f240c7692857355"
+      path: "./labels/imagenet_2012.txt"
+    - id: "preproc-aspect-ratio.json"
+      type: "file"
+      url: "https://raw.githubusercontent.com/open-edge-platform/edge-ai-libraries/3d2c76dcbc5b0f4aa0ac11d77873427c4c86fb22/libraries/dl-streamer/samples/gstreamer/model_proc/public/preproc-aspect-ratio.json"
+      sha256: "824db3e19e1e0a71caba8370606413b2bcd0d9339fb4c5b9535d4c3f2091095a"
+      path: "./labels/preproc-aspect-ratio.json"
+  target_fps: 14.95
+  consecutive_timeout_threshold: 2 
+  pipeline: |
+    filesrc location=./videos/6891009-apple_1080p15.mp4
+      ! ${DECODE_ELEMENTS}
+      ! queue
+      ! gvadetect batch-size=${BATCH_SIZE} model-instance-id=detection model=./models/yolo11n/int8/dynamic_half/yolo11n.xml 
+          threshold=0.5
+          device=${DEVICE_ID}
+          ${INFERENCE_ELEMENTS}
+      ! queue
+      ! gvatrack tracking-type=zero-term-imageless
+      ! queue 
+      ! gvaclassify batch-size=${BATCH_SIZE} model-instance-id=classifier
+          labels=./labels/imagenet_2012.txt
+          model=./models/efficientnet_b0/int8/efficientnet-b0.xml
+          model-proc=./labels/preproc-aspect-ratio.json
+          device=${DEVICE_ID}
+          ${INFERENCE_ELEMENTS}
+          reclassify-interval=1
+      ! queue
+  pipeline_params:
+    DECODE_ELEMENTS:
+      cpu: "qtdemux ! h264parse ! avdec_h264 ! video/x-raw"
+      gpu_integrated: "qtdemux ! h264parse ! vah264dec ! vapostproc ! capsfilter caps='video/x-raw(memory:VAMemory)'"
+      gpu_discrete: "qtdemux ! h264parse ! varenderD{RENDER_DEVICE_NUM}h264dec ! varenderD{RENDER_DEVICE_NUM}postproc ! capsfilter caps='video/x-raw(memory:VAMemory)'"
+      gpu_discrete_primary: "qtdemux ! h264parse ! vah264dec ! vapostproc ! capsfilter caps='video/x-raw(memory:VAMemory)'"
+      npu: "qtdemux ! h264parse ! vah264dec ! capsfilter caps='video/x-raw(memory:VAMemory)'"
+    INFERENCE_ELEMENTS:
+      cpu: "pre-process-backend={PRE_PROCESS_BACKEND} ie-config=CPU_THROUGHPUT_STREAMS=2 nireq=2"
+      gpu_integrated: "pre-process-backend={PRE_PROCESS_BACKEND} ie-config=GPU_THROUGHPUT_STREAMS=2 nireq=2 "
+      gpu_discrete: "pre-process-backend={PRE_PROCESS_BACKEND} ie-config=GPU_THROUGHPUT_STREAMS=2 nireq=2 "
+      gpu_discrete_primary: "pre-process-backend={PRE_PROCESS_BACKEND} ie-config=GPU_THROUGHPUT_STREAMS=2 nireq=2 "
+      npu: "pre-process-backend={PRE_PROCESS_BACKEND} nireq=4"
+    PRE_PROCESS_BACKEND:
+      cpu: "opencv"
+      gpu_integrated: "va-surface-sharing"
+      gpu_discrete: "va-surface-sharing"
+      gpu_discrete_primary: "va-surface-sharing"
+      npu: "opencv"
+    VIDEO_RAW_TYPE:
+      default: "'video/x-raw(memory:VAMemory)'"
+      overrides:
+        FULL_DEVICE_NAME:
+          "Intel(R) Unsupported video type": "'video/x-raw'"
+    BATCH_SIZE:
+      cpu: "8"
+      gpu_integrated: "8"
+      gpu_discrete: "8"
+      gpu_discrete_primary: "8"
+      npu: "1"
+    SINK_ELEMENT:
+      default: "fakesink sync=false async=false"
+    FPSCOUNTER_PROPS:
+      default: ""
+
+suites:
+  - name: "ai"
+    sub_suites:
+      - name: "vision"
+
+        tests:
+          test_dlstreamer:
+            params:              
+              - test_id: "VSN-VRB-001"
+                display_name: "DL Streamer Analysis - multi-stream 1080p15 H.264 gvadetect YOLO11n INT8 gvatrack gvaclassify EfficientNet-B0 INT8"
+                devices: [cpu,igpu,dgpu,npu]
+
+              - test_id: "VSN-VRB-002"
+                display_name: "DL Streamer Analysis - multi-stream 1080p15 H.264 gvadetect YOLO11n INT8 gvatrack gvaclassify EfficientNet-B0 INT8 (CPU)"
+                devices: [cpu]
+
+              - test_id: "VSN-VRB-003"
+                display_name: "DL Streamer Analysis - multi-stream 1080p15 H.264 gvadetect YOLO11n INT8 gvatrack gvaclassify EfficientNet-B0 INT8 (iGPU)"
+                devices: [igpu]
+                requirements:
+                  igpu_required: true
+
+              - test_id: "VSN-VRB-004"
+                display_name: "DL Streamer Analysis - multi-stream 1080p15 H.264 gvadetect YOLO11n INT8 gvatrack gvaclassify EfficientNet-B0 INT8 (dGPU)"
+                devices: [dgpu]
+                requirements:
+                  dgpu_required: true
+
+              - test_id: "VSN-VRB-005"
+                display_name: "DL Streamer Analysis - multi-stream 1080p15 H.264 gvadetect YOLO11n INT8 gvatrack gvaclassify EfficientNet-B0 INT8 (NPU)"
+                devices: [npu]
+                requirements:
+                  npu_required: true
+                


### PR DESCRIPTION
fix: update Vision AI qualification pipeline with new video assets (#847)

* chore: update Vision AI qualification pipeline with new video assets and models for multi-stream processing

* chore: update devices for DL Streamer Benchmark to CPU only

* chore: split Vision AI suite profiles for light and VRB configurations

* chore: add light and VRB configurations for vision profile in test benchmark

* chore: update video asset IDs and descriptions in AI Edge System and Vision VRB profiles; adjust estimated stream calculations in DLStreamer analyzer

* chore: update model and file asset URLs in AI Edge System and Vision VRB profiles

* chore: add consecutive timeout threshold to AI Edge System and Vision VRB profiles

* chore: update display names in AI Vision profiles for consistency
