### PR TITLE
fix: increase video loop duration to 120 seconds for Vision AI light pipeline (#876)

### DIFF
--- a/src/esq/configs/profiles/suites/ai_vision_light.yml
+++ b/src/esq/configs/profiles/suites/ai_vision_light.yml
@@ -31,7 +31,7 @@ params:
       height: 1080
       fps: 30
       codec: "h265"
-      loop: 30 # Loop to achieve ~30s duration
+      loop: 120 # Loop to achieve ~120s duration
     - id: "yolo11n"
       type: "model"
       source: "ultralytics"


### PR DESCRIPTION
fix: increase video loop duration to 120 seconds for Vision AI light pipeline (#876)

chore: increase video loop duration to 120 seconds for Vision AI light test case
