### PR TITLE
chore: support for qualification-only runs in CLI (#890)

### DIFF
--- a/src/sysagent/cli.py
+++ b/src/sysagent/cli.py
@@ -104,9 +104,10 @@ def main() -> int:
                 no_cache=args.no_cache,
                 filters=args.filter,
                 run_all_profiles=args.all,
+                qualification_only=args.qualification_only,
                 force=force,
                 no_mask=args.no_mask,
-                extra_args=[],  # No extra args from command line
+                extra_args=[],  # Placeholder for any future extra args
             )
         elif args.command == "info":
             run_system_info = get_command_function("run_system_info")

--- a/src/sysagent/utils/cli/commands/run.py
+++ b/src/sysagent/utils/cli/commands/run.py
@@ -90,6 +90,7 @@ def run_tests(
     no_cache: bool = False,
     filters: List[str] = None,
     run_all_profiles: bool = False,
+    qualification_only: bool = False,
     force: bool = False,
     no_mask: bool = False,
     extra_args: List[str] = None,
@@ -111,6 +112,7 @@ def run_tests(
         run_all_profiles: Whether to run all profile types.
                           If False, only qualification and vertical profiles are run by default
                           with an opt-out prompt for vertical profiles.
+        qualification_only: Whether to run qualification profiles only (skips vertical and suite profiles)
         force: Whether to skip interactive prompts and use default behavior
         no_mask: Whether to disable masking of data in system information
         extra_args: Additional pytest arguments to pass
@@ -197,7 +199,7 @@ def run_tests(
         # Option 3: Run all profiles if no specific profile or suite is provided
         else:
             result_code, tests_ran = _run_all_profiles(
-                skip_system_check, data_dir, verbose, debug, run_all_profiles, force
+                skip_system_check, data_dir, verbose, debug, run_all_profiles, qualification_only, force
             )
 
     except KeyboardInterrupt:
@@ -438,6 +440,7 @@ def _run_all_profiles(
     verbose: bool,
     debug: bool,
     run_all_profiles: bool = False,
+    qualification_only: bool = False,
     force: bool = False,
 ) -> tuple:
     """Run all available profiles or qualification+vertical profiles by default with opt-out prompt.
@@ -449,6 +452,7 @@ def _run_all_profiles(
         debug: Whether to enable debug output
         run_all_profiles: If False (default), run qualification and vertical profiles with opt-out prompt.
                           If True, run all profile types (qualifications, suites, verticals) without prompt.
+        qualification_only: If True, run qualification profiles only (skips vertical and suite profiles)
         force: Whether to skip interactive prompts and use default behavior
 
     Returns:
@@ -485,6 +489,11 @@ def _run_all_profiles(
         include_all_types = True
         skip_vertical_profiles = False
         logger.info("Running all profile types (qualifications, verticals, suites)")
+    elif qualification_only:
+        # --qualification-only option: run qualification profiles only without prompts
+        include_all_types = False
+        skip_vertical_profiles = True
+        logger.info("Running qualification profiles only")
     else:
         # Default behavior: run qualification + vertical with opt-out prompt for vertical
         include_all_types = False

--- a/src/sysagent/utils/cli/parsers.py
+++ b/src/sysagent/utils/cli/parsers.py
@@ -57,13 +57,16 @@ USAGE PATTERNS:
   1. Run qualification and vertical profiles with opt-out prompt (default):
      {cli_name} run
 
-  2. Run all available profiles:
+  2. Run qualification profiles only (no prompt):
+     {cli_name} run --qualification-only
+
+  3. Run all available profiles:
      {cli_name} run --all
 
-  3. Run a specific profile:
+  4. Run a specific profile:
      {cli_name} run -p PROFILE_NAME
 
-  4. Run with filters:
+  5. Run with filters:
      {cli_name} run -p PROFILE_NAME --filter test_id=T0069
      {cli_name} run -p PROFILE_NAME --filter display_name="CPU Test"
      {cli_name} run -p PROFILE_NAME --filter test_id=T0069 --filter devices=cpu
@@ -71,6 +74,7 @@ USAGE PATTERNS:
 EXAMPLES:
   {cli_name} run                                      # Run qualification + vertical profiles (with opt-out prompt)
   {cli_name} run --force                              # Skip prompt, use default (include vertical profiles)
+  {cli_name} run --qualification-only                 # Run qualification profiles only (no vertical/suite profiles)
   {cli_name} run --all                                # Run all profile types
   {cli_name} run -p profile.suite.ai.vision           # Run specific profile
 
@@ -86,6 +90,12 @@ For available profiles, use: {cli_name} list
         "-a",
         action="store_true",
         help=("Run all profile types. By default, qualification and vertical profiles are run with an opt-out prompt."),
+    )
+    execution_group.add_argument(
+        "--qualification-only",
+        "-qo",
+        action="store_true",
+        help="Run qualification profiles only (skips vertical and suite profiles without prompting)",
     )
     execution_group.add_argument(
         "--profile", "-p", metavar="PROFILE_NAME", help="Run a specific profile (e.g., profile.suite.ai-vision)"


### PR DESCRIPTION
ci: enable CI workflow to avoid docker pull rate limiting and enhance workflow (#890)

* ci: enable CI workflow to avoid docker pull rate limiting

* ci: enhance CI workflows with custom profile support and runner selection

* ci: add support for qualification-only runs in CLI and workflows
