### PR TITLE
feat: Integrate AI Frequency long run test suite (#774)

### DIFF
--- a/src/esq/configs/profiles/suites/sys_gpu_ov.yml
+++ b/src/esq/configs/profiles/suites/sys_gpu_ov.yml
@@ -1,0 +1,53 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+name: "profile.suite.system.gpu-ov"
+description: "System GPU Performance suite using OpenVINO benchmark"
+version: "1.0.0"
+params:
+  labels:
+    profile_display_name: "System GPU"
+    group: "system.gpu"
+    type: "suite"
+    display_status: false
+  requirements:
+    # Hardware requirements
+    cpu_min_cores: 2
+    memory_min_gb: 5.0
+    storage_total_min_gb: 64.0
+    storage_min_gb: 10.0 # Free storage for test execution
+    # Software requirements
+    os_type:
+      - "linux"
+    docker_required: true
+  container_image: "ai_freq_measure"
+  image_tag: "1.0"
+  dockerfile_name: "Dockerfile"
+  base_image: "intel/dlstreamer:2025.1.2-ubuntu24"
+
+suites:
+  - name: "system"
+    sub_suites:
+      - name: "gpu"
+        tests:
+          test_system_gpu:
+            params:
+              - test_id: "GPU-OBM-001"
+                display_name: "AI GPU Frequency Measure - OV Benchmark yolo-v5s FP16 (iGPU)"
+                models: ["yolov5s"]
+                precision: "FP16"
+                device: igpu
+                duration_hrs: 0.08
+                timeout: 200
+                requirements:
+                  igpu_required: true
+
+              - test_id: "GPU-OBM-002"
+                display_name: "AI GPU Frequency Measure - OV Benchmark yolo-v5s FP16 (dGPU)"
+                models: ["yolov5s"]
+                precision: "FP16"
+                device: dgpu
+                duration_hrs: 0.08
+                timeout: 200
+                requirements:
+                  dgpu_required: true

--- a/src/esq/configs/profiles/verticals/metro.yml
+++ b/src/esq/configs/profiles/verticals/metro.yml
@@ -13,6 +13,7 @@ params:
     display_status: false
   depends_on:
     - "profile.suite.system.memory-stream"
+    - "profile.suite.system.gpu-ov"
     - "profile.suite.ai.vision-ov"
   requirements:
     # Hardware requirements

--- a/src/esq/suites/system/gpu/src/containers/ai_frequency_measure/AI_box_runtimeDL.py
+++ b/src/esq/suites/system/gpu/src/containers/ai_frequency_measure/AI_box_runtimeDL.py
@@ -1,0 +1,729 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import datetime
+import logging
+import os
+import re
+import shlex
+import shutil
+import subprocess as sp  # nosec B404
+import sys
+import warnings
+from pathlib import Path
+
+import matplotlib as mpl
+import openvino as ov
+import pandas as pd
+from bcmk_telemetry import is_intel_xeon, telemetry_decorator
+
+mpl.use("Agg")
+from matplotlib import pyplot as plt
+
+logger = logging.getLogger(__name__)
+
+if len(sys.argv) < 3 or not sys.argv[2]:
+    logger.error("Error: Missing numeric argument")
+    sys.exit(1)
+
+device_arg = sys.argv[1]
+time_arg = sys.argv[2]
+
+__Device = device_arg  # string directly, no need to str()
+if not isinstance(__Device, str):
+    logger.error(f"Device argument is invalid: '{device_arg}'")
+    sys.exit(1)
+
+try:
+    __TimeOfStableRun = float(time_arg)  # hours
+except ValueError:
+    logger.error(f"Input duration is invalid: '{time_arg}'")
+    sys.exit(1)
+
+if __TimeOfStableRun < 0.01:
+    __TimeOfStableRun = 0.01
+
+__TimeOfStableRun = int(__TimeOfStableRun * 3600)
+
+warnings.filterwarnings("ignore", category=UserWarning, module="pandas")
+mpl.rcParams["font.size"] = 11
+# Time of GpuWatch should be modified in shell scripts.
+
+CURR_DIR = os.path.dirname(os.path.abspath(__file__))
+OUTPUT_DIR = Path(f"{CURR_DIR}/output").resolve()
+if not OUTPUT_DIR.exists():
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+logger = logging.getLogger()
+EXECUTION_DIR = "/home/dlstreamer/openvino_cpp_samples_build/intel64/Release"
+
+LOG_PREF = re.sub(r"\W+", "", __Device)
+OUTPUT_LOG = f"{LOG_PREF}-IntelVideoAIBoxDetails.log"
+RUNTIME_LOG = f"{LOG_PREF}-stable_runtime.txt"
+OUTPUT_IMG = f"{LOG_PREF}_InferencePerformance_FreqPlot.png"
+
+
+def LogConfig():
+    logger.setLevel(level=logging.INFO)
+    handler = logging.FileHandler(OUTPUT_DIR / f"{OUTPUT_LOG}")
+    handler.setLevel(logging.INFO)
+    formatter = logging.Formatter(
+        "[%(asctime)s.%(msecs)03d][%(filename)s][%(funcName)s][%(lineno)d]%(message)s", datefmt="%H:%M:%S"
+    )
+    handler.setFormatter(formatter)
+    streamHandler = logging.StreamHandler()
+    streamHandler.setLevel(logging.DEBUG)
+    streamHandler.setFormatter(formatter)
+    logger.addHandler(handler)
+    # logger.addHandler(streamHandler)
+
+
+def Initial():
+    abs_path = get_file_abs_path("runtime")
+    # Remove file safely
+    if os.path.exists(abs_path):
+        try:
+            os.remove(abs_path)
+            logger.info(f"Removed old log file: {abs_path}")
+        except OSError as e:
+            logger.error(f"Failed to remove {abs_path}: {e}")
+    else:
+        os.makedirs(f"{OUTPUT_DIR}", exist_ok=True)
+        logger.info("Creating result dir ...")
+
+    logger.info("+------------------------------+")
+    logger.info("|   Intel AI Box Test Tool     |")
+    logger.info("+------------------------------+")
+    logger.info("|Test Processor: {} |".format(GetProcessorName()))
+    logger.info("+-------------------------------------------+")
+    logger.info("|Test StartTime: {} |".format(datetime.datetime.now()))
+    logger.info("+-------------------------------------------+")
+
+
+def get_file_abs_path(file_type):
+    """Ensure file_path is inside OUTPUT_DIR and name is safe."""
+    base_dir = os.path.abspath(f"{OUTPUT_DIR}")
+
+    if file_type == "outlog":
+        file_path = os.path.join(base_dir, OUTPUT_LOG)
+    elif file_type == "runtime":
+        file_path = os.path.join(base_dir, RUNTIME_LOG)
+    elif file_type == "outimg":
+        file_path = os.path.join(base_dir, OUTPUT_IMG)
+
+    abs_path = Path(file_path).resolve()
+
+    # Ensure the target file stays inside OUTPUT_DIR
+    if not str(abs_path).startswith(str(base_dir) + os.sep):
+        logger.error(f"Invalid path: {abs_path} not within {base_dir}")
+        sys.exit(1)
+
+    # Allow only safe filename characters
+    filename = abs_path.name
+    if not re.match(r"^[\w.\-]+$", filename):
+        logger.error(f"Unsafe filename detected: {filename}")
+        sys.exit(1)
+
+    return abs_path
+
+
+def check_npu_device():
+    # so far, have to use cpp benchmark_app to check if NPU is available device.
+
+    benchmark_path = shutil.which("benchmark_app")
+    if not benchmark_path:
+        raise FileNotFoundError("benchmark_app not found")
+
+    result = sp.run(
+        [benchmark_path, "-h"], cwd=EXECUTION_DIR, shell=False, text=True, stdout=sp.PIPE, stderr=sp.PIPE, check=True
+    )
+    lines = result.stdout.splitlines()
+    npu_lines = [line for line in lines if "Available target devices" in line and "NPU" in line]
+
+    return len(npu_lines) > 0
+
+
+def get_gpu_device():
+    core = ov.Core()
+    devices = core.get_available_devices()
+    gpu_devices = [dev for dev in devices if dev.startswith("GPU")]
+    dgpu_devices = [dev for dev in gpu_devices if "iGPU" not in core.get_property(dev, "FULL_DEVICE_NAME")]
+
+    if not gpu_devices:
+        test_devices = ["CPU"]
+    elif not dgpu_devices:
+        test_devices = gpu_devices
+    else:
+        test_devices = dgpu_devices
+
+    if len(test_devices) > 1:
+        multi_devices = ",".join(test_devices)
+        return f"MULTI:{multi_devices}"
+    else:
+        return "GPU.0" if test_devices[0] == "GPU" else test_devices[0]
+
+
+def GetProcessorName():
+    try:
+        with open("/proc/cpuinfo", "r") as f:
+            for line in f:
+                if "model name" in line.lower():
+                    cpu_info = line.strip().split(":", 1)[1].strip()
+
+                    # Default processor name
+                    processor_name = cpu_info
+
+                    # Match variants like "Intel(R) Core(TM) i7-12700H"
+                    if "Core(TM)" in cpu_info:
+                        match = re.search(r"Core\(TM\)\s+(.*)", cpu_info)
+                        if match:
+                            processor_name = match.group(1).strip()
+
+                    elif "Celeron(R)" in cpu_info or "Xeon(R)" in cpu_info:
+                        match = re.search(r"\(R\)\s+(.*)", cpu_info)
+                        if match:
+                            processor_name = match.group(1).strip()
+
+                    return processor_name
+
+        return "Unknown Processor"
+
+    except Exception as e:
+        return f"Error reading CPU info: {e}"
+
+
+def TestStarter():
+    telemetry_data = RunStable_Bcmk()
+    cpu_util_list = telemetry_data["CPU_Usage"]
+    cpu_freq_list = telemetry_data["CPU_Freq"]
+
+    gpu_usage = telemetry_data.get("GPU_Usage", {})
+    if gpu_usage:
+        igpu_usage_list = gpu_usage.get("igpu", None)
+        dgpu_usage_list = gpu_usage.get("dgpu", None)
+        # Extract dGPU selection metadata
+        dgpu_device_id = gpu_usage.get("dgpu_device_id", None)
+        dgpu_count = gpu_usage.get("dgpu_count", 0)
+        dgpu_power_list = telemetry_data.get("dGPU_Power", None)
+    else:
+        igpu_usage_list = None
+        dgpu_usage_list = None
+        dgpu_device_id = None
+        dgpu_count = 0
+        dgpu_power_list = None
+
+    cpu_merged_df = pd.merge(
+        cpu_util_list[["date", "sum"]], cpu_freq_list[["date", "max_freq"]], on="date", how="inner"
+    )
+
+    dfs = [cpu_merged_df, igpu_usage_list, dgpu_usage_list, dgpu_power_list]
+    min_row_num = min(len(df) for df in dfs if df is not None and not df.empty)
+
+    # align the data
+    # min_row_num = min(len(cpu_merged_df), len(igpu_usage_list))
+
+    cpu_merged_df_adjusted = cpu_merged_df.iloc[-min_row_num:]
+    if igpu_usage_list is not None:
+        igpu_usage_list_adjusted = igpu_usage_list.iloc[-min_row_num:]
+        igpu_usage_list_adjusted["date"] = cpu_merged_df_adjusted["date"].values
+    else:
+        igpu_usage_list_adjusted = None
+
+    if dgpu_usage_list is not None:
+        dgpu_usage_list_adjusted = dgpu_usage_list.iloc[-min_row_num:]
+        dgpu_usage_list_adjusted["date"] = cpu_merged_df_adjusted["date"].values
+    else:
+        dgpu_usage_list_adjusted = None
+
+    if dgpu_power_list is not None:
+        dgpu_power_list_adjusted = dgpu_power_list.iloc[-min_row_num:]
+        # dgpu_usage_list_adjusted['date'] = cpu_merged_df_adjusted['date'].values
+    else:
+        dgpu_power_list_adjusted = None
+
+    ParseStableRuntime(get_file_abs_path("outlog"))
+    # draw the data in one graph - pass dGPU metadata
+    draw_graph(cpu_merged_df_adjusted, igpu_usage_list_adjusted, dgpu_usage_list_adjusted, dgpu_power_list_adjusted, dgpu_device_id, dgpu_count)
+
+
+def extract_value(line):
+    m = re.search(r"\d+\.\d+", line)
+    try:
+        return m.group()
+    except:
+        return ""
+
+
+def fetch_cpu_info():
+    # Function to execute a command and return its output
+    def execute_command(command):
+        result = sp.run(command, shell=False, text=True, capture_output=True, check=True)
+        return result.stdout.strip()
+
+    # Execute lscpu and capture its output
+    lscpu_output = execute_command(["lscpu"])
+
+    # Function to find a value using a regex pattern from the lscpu output
+    def find_value(pattern):
+        match = re.search(pattern, lscpu_output)
+        if match:
+            return int(match.group(1))
+        return None
+
+    # Extracting required information using regex
+    sockets_num = find_value(r"Socket\(s\):\s*(\d+)")
+    cores_per_socket = find_value(r"Core\(s\) per socket:\s*(\d+)")
+    numa_nodes_num = find_value(r"NUMA node\(s\):\s*(\d+)")
+
+    # Calculating values
+    physical_cores_num = sockets_num * cores_per_socket if sockets_num and cores_per_socket else None
+    cores_per_node = physical_cores_num // numa_nodes_num if physical_cores_num and numa_nodes_num else None
+    cores_per_instance = cores_per_node
+
+    # Returning the calculated values
+    return {
+        "sockets_num": sockets_num,
+        "cores_per_socket": cores_per_socket,
+        "physical_cores_num": physical_cores_num,
+        "numa_nodes_num": numa_nodes_num,
+        "cores_per_node": cores_per_node,
+        "cores_per_instance": cores_per_instance,
+    }
+
+
+def run_spr_ov_bcmk(bcmk_dir, model_path, exec_cores_per_socket=0, time=90):
+    benchmark_app_bin = bcmk_dir + "/benchmark_app"
+
+    cpu_info = fetch_cpu_info()
+    logging.info(f"Get CPU INFO: {cpu_info}")
+
+    sockets_num = cpu_info["sockets_num"]
+    cores_per_socket = cpu_info["cores_per_socket"]
+    exec_cores_per_socket = cores_per_socket if exec_cores_per_socket <= 0 else exec_cores_per_socket
+
+    numa_cmds = []
+    for i, socket in enumerate(range(sockets_num)):
+        start_core_idx = i * cores_per_socket
+        end_core_idx = start_core_idx + exec_cores_per_socket - 1
+        numa_cmd = [
+            "numactl",
+            "-m",
+            str(i),
+            "--physcpubind",
+            f"{start_core_idx}-{end_core_idx}",
+            benchmark_app_bin,
+            "-m",
+            model_path,
+            "-t",
+            str(time),
+        ]
+        logging.info(f"Benchmark App command with numactl: {numa_cmd}")
+        numa_cmds.append(numa_cmd)
+
+    raw_out = []
+    try:
+        for _cmd in numa_cmds:
+            # Ensure the command is a list, not a string
+            if isinstance(_cmd, str):
+                _cmd = shlex.split(_cmd)
+
+            # Safety: only allow numactl commands
+            if not _cmd or not _cmd[0].endswith("numactl"):
+                raise ValueError(f"Untrusted command: {_cmd}")
+
+            result = sp.run(
+                _cmd,
+                text=True,
+                stdout=sp.PIPE,
+                stderr=sp.PIPE,
+                timeout=time + 30,
+                check=False,  # We handle errors manually
+            )
+
+            if result.stderr:
+                logging.error(f"Error occurred: {result.stderr}")
+
+            raw_out.append(result.stdout)
+    except sp.CalledProcessError as ex:
+        logger.error(f"Execute benchmark app with model {model_name} on SPR platform Failed. ")
+        logger.error(ex.returncode)
+        logger.error(ex.output)
+
+    return raw_out
+
+
+@telemetry_decorator
+def RunStable_Bcmk():
+    test_model_name = choose_model_4test()
+    share_base = "/home/dlstreamer/share"
+    models_base = f"{share_base}/models"  # Models mounted from esq_data/data/vertical/metro/models
+    images_base = f"{share_base}/images"  # Images mounted from esq_data/data/vertical/metro/images
+
+    # Model path structure: share/models/{model}/FP16/{model}.xml
+    # Mounted from: esq_data/data/vertical/metro/models
+    possible_paths = [
+        f"{models_base}/{test_model_name}/FP16/{test_model_name}.xml",
+    ]
+
+    model_path = None
+    for path in possible_paths:
+        if os.path.exists(path):
+            model_path = path
+            logger.info(f"Found model at: {model_path}")
+            break
+
+    if not model_path:
+        logger.error(f"Model file not found for: {test_model_name}")
+        logger.error("Searched paths:")
+        for path in possible_paths:
+            logger.error(f"  - {path}")
+        # List what's actually in the share directory
+        if os.path.exists(share_base):
+            logger.error(f"Contents of {share_base}:")
+            for root, dirs, files in os.walk(share_base):
+                level = root.replace(share_base, "").count(os.sep)
+                indent = " " * 2 * level
+                logger.error(f"{indent}{os.path.basename(root)}/")
+                subindent = " " * 2 * (level + 1)
+                for file in files[:10]:  # Limit files shown
+                    logger.error(f"{subindent}{file}")
+        raise FileNotFoundError(f"Model XML not found for: {test_model_name}")
+
+    # Test image is in the images directory
+    test_image_path = f"{images_base}/car.png"
+
+    if not os.path.exists(test_image_path):
+        logger.error(f"Test image not found: {test_image_path}")
+        logger.error(f"Expected location: {images_base}/car.png")
+        # List images directory contents
+        if os.path.exists(images_base):
+            logger.error(f"Contents of {images_base}: {os.listdir(images_base)}")
+        raise FileNotFoundError(f"Test image not found: {test_image_path}")
+
+    logger.info(f"Using model: {test_model_name} at {model_path}")
+    logger.info(f"Using test image: {test_image_path}")
+
+    if not is_intel_xeon() or __Device != "CPU":
+        # Build command as list for proper argument handling
+        cmd_list = [
+            "./benchmark_app",
+            "-d",
+            __Device,
+            "-m",
+            model_path,
+            "-i",
+            test_image_path,
+            "-t",
+            str(__TimeOfStableRun),
+        ]
+
+        logger.info(f"Running benchmark_app command: {' '.join(cmd_list)}")
+
+        try:
+            result = sp.run(cmd_list, cwd=EXECUTION_DIR, capture_output=True, text=True, check=True)
+            output_filename = get_file_abs_path("outlog")
+
+            try:
+                with open(output_filename, "w") as output_file:
+                    output_file.write(result.stdout)
+            except OSError as e:
+                logger.error(f"Error writing to file {output_filename}: {e}")
+
+        except sp.CalledProcessError as e:
+            logger.error(f"benchmark_app failed with exit code {e.returncode}")
+            logger.error(f"Command: {' '.join(cmd_list)}")
+            logger.error(f"STDOUT: {e.stdout}")
+            logger.error(f"STDERR: {e.stderr}")
+
+            # Try to provide helpful diagnostics
+            logger.error("=== Diagnostics ===")
+            logger.error(f"Model XML exists: {os.path.exists(model_path)}")
+            logger.error(f"Image file exists: {os.path.exists(test_image_path)}")
+            logger.error(f"benchmark_app exists: {os.path.exists(os.path.join(EXECUTION_DIR, 'benchmark_app'))}")
+
+            # Check model file sizes
+            if os.path.exists(model_path):
+                try:
+                    xml_size = os.path.getsize(model_path)
+                    logger.error(f"Model XML size: {xml_size} bytes")
+                    bin_path = model_path.replace(".xml", ".bin")
+                    if os.path.exists(bin_path):
+                        bin_size = os.path.getsize(bin_path)
+                        logger.error(f"Model BIN size: {bin_size} bytes")
+                    else:
+                        logger.error(f"Model BIN file MISSING: {bin_path}")
+                except Exception as size_err:
+                    logger.error(f"Error checking model files: {size_err}")
+
+            raise
+    else:
+        out_list = run_spr_ov_bcmk(EXECUTION_DIR, model_path, time=__TimeOfStableRun)
+        output_filename = get_file_abs_path("outlog")
+        try:
+            with open(output_filename, "w") as output_file:
+                for out_line in out_list:
+                    output_file.write(out_line)
+        except OSError as e:
+            logger.error(f"Error writing to file {output_filename}: {e}")
+
+
+def ParseStableRuntime(file_path):
+    Network = 0  # Use Yolo_v4 Network
+    nn_model = choose_model_4test()
+    pattern = r"Throughput: (.*?) FPS"
+
+    output_filename = get_file_abs_path("runtime")
+    try:
+        with open(output_filename, "w") as result:
+            result.write("Network: {} Device: {}\n".format(nn_model, __Device))
+    except OSError as e:
+        logger.error(f"Error writing to file {output_filename}: {e}")
+
+    with open(file_path, "r") as f:
+        lines = f.readlines()
+        for line in reversed(lines):
+            match = re.findall(pattern, line)
+            if match:
+                fps_log = float(match[0].strip())
+                runtime_file = get_file_abs_path("runtime")
+                try:
+                    with open(get_file_abs_path("runtime"), "a") as result:
+                        result.write(
+                            "Duration time: {:.3f}h Average FPS: {:.2f}\n".format(__TimeOfStableRun / 3600, fps_log)
+                        )
+                    logger.info("Duration time: {:.3f}h Average FPS: {:.2f}".format(__TimeOfStableRun / 3600, fps_log))
+                except OSError as e:
+                    logger.error(f"Error writing to file {runtime_file}: {e}")
+
+
+def DataParser(output_folder):
+    ParseStableRuntime(get_file_abs_path("outlog"))
+
+def draw_graph(cpu_df, igpu_df, dgpu_df, dgpu_power_df, dgpu_device_id=None, dgpu_count=0):
+    # Initialize Metrics with default values including stability metrics
+    summary_df = pd.DataFrame(
+        [
+            {
+                "Function": "AI-Freq-LR",
+                # iGPU performance metrics
+                "frequency_max_igpu": 0.0,
+                "utilization_igpu": 0.0,
+                "max_power_igpu": 0.0,
+                # iGPU stability metrics (lower is better)
+                "frequency_stddev_igpu": 0.0,
+                "frequency_min_igpu": 0.0,
+                "frequency_range_igpu": 0.0,
+                # dGPU performance metrics
+                "frequency_max_dgpu": 0.0,
+                "utilization_dgpu": 0.0,
+                "max_power_dgpu": 0.0,
+                # dGPU stability metrics (lower is better)
+                "frequency_stddev_dgpu": 0.0,
+                "frequency_min_dgpu": 0.0,
+                "frequency_range_dgpu": 0.0,
+                # CPU metrics
+                "utilization_cpu": 0.0,
+                "frequency_max_cpu": 0.0,
+                # dGPU selection metadata
+                "dgpu_device_id": dgpu_device_id if dgpu_device_id else "N/A",
+                "dgpu_count": dgpu_count,
+            }
+        ]
+    )
+
+    cpu_df["date"] = pd.to_datetime(cpu_df["date"])
+    cpu_df.sort_values("date", inplace=True)
+    if igpu_df is not None:
+        igpu_df["date"] = pd.to_datetime(igpu_df["date"])
+        igpu_df.sort_values("date", inplace=True)
+    if dgpu_df is not None:
+        dgpu_df["date"] = pd.to_datetime(dgpu_df["date"])
+        dgpu_df.sort_values("date", inplace=True)
+
+    if igpu_df is not None and "pkg_power" in igpu_df.columns or dgpu_df is not None and "pkg_power" in dgpu_df.columns:
+        fig, (ax1, ax2, ax3) = plt.subplots(3, 1, figsize=(14, 8), sharex=True)
+    else:
+        fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(14, 8), sharex=True)
+
+    ax1.set_xlabel("Date")
+    ax1.set_ylabel("Device Utilization (%)", color="tab:blue")
+    ax1.plot(cpu_df["date"], cpu_df["sum"], label="Norm CPU Utilization", color="#000080", linestyle="-")
+
+    summary_df.at[0, "utilization_cpu"] = round(cpu_df["sum"].mean(), 2)
+
+    if igpu_df is not None:
+        ax1.plot(igpu_df["date"], igpu_df["gpu_util"], label="iGPU Utilization", color="#4169E1", linestyle="--")
+        summary_df.at[0, "utilization_igpu"] = round(igpu_df["gpu_util"].mean(), 2)
+    if dgpu_df is not None:
+        ax1.plot(dgpu_df["date"], dgpu_df["gpu_util"], label="dGPU Utilization", color="#87CEEB", linestyle="-.")
+        summary_df.at[0, "utilization_dgpu"] = round(dgpu_df["gpu_util"].mean(), 2)
+    ax1.tick_params(axis="y", labelcolor="tab:blue")
+    ax1.set_ylim(-5, 110)
+    ax1.legend(bbox_to_anchor=(1.05, 1), loc="upper left")
+
+    ax2 = ax2
+    ax2.set_ylabel("Device Frequency (GHz)", color="tab:orange")
+    ax2.plot(cpu_df["date"], cpu_df["max_freq"], label="CPU Max Frequency", color="#FF8C00", marker="x", linestyle="-")
+    summary_df.at[0, "frequency_max_cpu"] = round(cpu_df["max_freq"].mean(), 2)
+
+    if igpu_df is not None:
+        ax2.plot(
+            igpu_df["date"], igpu_df["gpu_freq"], label="iGPU Frequency", color="#FFA500", marker="x", linestyle="--"
+        )
+        # Performance metrics
+        summary_df.at[0, "frequency_max_igpu"] = round(igpu_df["gpu_freq"].mean(), 2)
+        # Stability metrics (lower is better for consistency)
+        summary_df.at[0, "frequency_stddev_igpu"] = round(igpu_df["gpu_freq"].std(), 4)
+        summary_df.at[0, "frequency_min_igpu"] = round(igpu_df["gpu_freq"].min(), 2)
+        freq_range_igpu = igpu_df["gpu_freq"].max() - igpu_df["gpu_freq"].min()
+        summary_df.at[0, "frequency_range_igpu"] = round(freq_range_igpu, 4)
+
+    if dgpu_df is not None:
+        ax2.plot(
+            dgpu_df["date"], dgpu_df["gpu_freq"], label="dGPU Frequency", color="#FFD700", marker="x", linestyle="-."
+        )
+        # Performance metrics
+        summary_df.at[0, "frequency_max_dgpu"] = round(dgpu_df["gpu_freq"].mean(), 2)
+        # Stability metrics (lower is better for consistency)
+        summary_df.at[0, "frequency_stddev_dgpu"] = round(dgpu_df["gpu_freq"].std(), 4)
+        summary_df.at[0, "frequency_min_dgpu"] = round(dgpu_df["gpu_freq"].min(), 2)
+        freq_range_dgpu = dgpu_df["gpu_freq"].max() - dgpu_df["gpu_freq"].min()
+        summary_df.at[0, "frequency_range_dgpu"] = round(freq_range_dgpu, 4)
+
+    ax2.tick_params(axis="y", labelcolor="tab:orange")
+    ax2.set_ylim(-1, 2.5)
+    ax2.legend(bbox_to_anchor=(1.05, 1), loc="upper left")
+
+    show_power_plot = False
+    if igpu_df is not None and "pkg_power" in igpu_df.columns or dgpu_df is not None and "pkg_power" in dgpu_df.columns:
+        show_power_plot = True
+        ax3_right_spine = ax3
+
+    if show_power_plot:
+        ax3.set_xlabel("Date")
+        ax3.set_ylabel("Power (W)", color="tab:purple")
+        if igpu_df is not None:
+            ax3_right_spine.plot(
+                igpu_df["date"],
+                igpu_df["pkg_power"],
+                label="iGPU Power",
+                color="#1E90FF",
+                marker="o",
+                linestyle="--",
+            )
+            summary_df.at[0, "max_power_igpu"] = round(igpu_df["pkg_power"].mean(), 2)
+
+        # Plot dGPU power - prefer xpu-smi data, fallback to pkg_power from intel_gpu_top
+        dgpu_power_plotted = False
+        if dgpu_power_df is not None:
+            # Calculate mean, skipping NaN values (converted from N/A)
+            power_mean = dgpu_power_df["GPU Power (W)"].mean(skipna=True)
+            # Only use xpu-smi data if we have valid values
+            if not pd.isna(power_mean) and power_mean > 0:
+                ax3_right_spine.plot(
+                    dgpu_power_df["date"],
+                    dgpu_power_df["GPU Power (W)"],
+                    label="dGPU Power (xpu-smi)",
+                    color="#DC143C",
+                    marker="o",
+                    linestyle="-.",
+                )
+                summary_df.at[0, "max_power_dgpu"] = round(power_mean, 2)
+                dgpu_power_plotted = True
+
+        # Fallback to pkg_power from intel_gpu_top if xpu-smi data not available
+        if not dgpu_power_plotted and dgpu_df is not None and "pkg_power" in dgpu_df.columns:
+            pkg_power_mean = dgpu_df["pkg_power"].mean(skipna=True)
+            if not pd.isna(pkg_power_mean):
+                ax3_right_spine.plot(
+                    dgpu_df["date"],
+                    dgpu_df["pkg_power"],
+                    label="dGPU Power (pkg)",
+                    color="#DC143C",
+                    marker="o",
+                    linestyle="-.",
+                )
+                summary_df.at[0, "max_power_dgpu"] = round(pkg_power_mean, 2)
+                dgpu_power_plotted = True
+
+        # Default to 0.0 if no power data available
+        if not dgpu_power_plotted and dgpu_df is not None:
+            summary_df.at[0, "max_power_dgpu"] = 0.0
+
+        ax3_right_spine.tick_params(axis="y", labelcolor="tab:purple")
+        ax3_right_spine.set_ylim(-5, 120)
+        ax3_right_spine.legend(bbox_to_anchor=(1.05, 1), loc="upper left")
+
+    runtime_file = get_file_abs_path("runtime")
+    try:
+        with open(runtime_file, "r") as f:
+            title = f.read()
+            # Add suffix if multiple dGPUs detected and best device selected
+            if dgpu_count > 1 and dgpu_device_id:
+                title = f"{title} - Best Device: {dgpu_device_id}"
+            fig.suptitle(title)
+    except OSError as e:
+        logger.error(f"Error reading runtime file {runtime_file}: {e}")
+
+    fig.autofmt_xdate()
+
+    plt.tight_layout(rect=[0, 0, 1, 0.96])
+    logger.info(f"Creating the PNG Image and saving it {OUTPUT_DIR}/")
+    plt.savefig(get_file_abs_path("outimg"))
+
+    summary_df.to_csv(f"{OUTPUT_DIR}/averages_summary.csv", index=False)
+
+    logger.info("Averages saved to averages_summary.csv")
+
+    # Log dGPU selection information
+    if dgpu_count > 0:
+        logger.info(f"dGPU Selection Summary: {dgpu_count} device(s) detected")
+        if dgpu_device_id:
+            logger.info(f"  Selected device: {dgpu_device_id}")
+            if dgpu_count > 1:
+                logger.info("  Selection based on: highest avg frequency + lowest stddev (stability)")
+        logger.info(f"  dGPU metrics in summary: frequency_max={summary_df.at[0, 'frequency_max_dgpu']:.2f} GHz, "
+                   f"stddev={summary_df.at[0, 'frequency_stddev_dgpu']:.4f}, "
+                   f"utilization={summary_df.at[0, 'utilization_dgpu']:.2f}%")
+
+def choose_model_4test():
+    """
+    Determine which model to use for testing.
+
+    Priority:
+    1. MODEL_NAME environment variable (set by test framework)
+       - Test framework handles CPU detection and selects appropriate model
+       - Atom/Celeron → yolov5n (set by test)
+       - Core/Xeon → yolov5s (set by test)
+    2. Default to yolov5s if MODEL_NAME not set
+
+    Returns:
+        str: Model name (e.g., 'yolov5n', 'yolov5s', 'yolov5m')
+    """
+    # Check for MODEL_NAME environment variable (set by test framework)
+    # Test framework already handles CPU-based model selection
+    env_model = os.environ.get("MODEL_NAME")
+    if env_model:
+        logger.info(f"Using model from test framework: {env_model}")
+        return env_model
+
+    # Default fallback (should rarely be used - test framework sets MODEL_NAME)
+    logger.info("MODEL_NAME not set, defaulting to yolov5s")
+    return "yolov5s"
+
+def main():
+    output_folder = f"{OUTPUT_DIR}"
+    if not os.path.exists(output_folder):
+        os.makedirs(output_folder)
+    LogConfig()
+    logger.info("Initializing the AI Freq Runner!!")
+    Initial()
+    TestStarter()
+    # DataParser(output_folder)
+
+
+if __name__ == "__main__":
+    # __Device = get_gpu_device()
+    logger.info(f"AI Frequency Runner Input Device: {__Device}")
+    logger.info(f"AI FRequency Runner Input Test Duration: {__TimeOfStableRun}")
+    main()

--- a/src/esq/suites/system/gpu/src/containers/ai_frequency_measure/Dockerfile
+++ b/src/esq/suites/system/gpu/src/containers/ai_frequency_measure/Dockerfile
@@ -1,0 +1,69 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+ARG COMMON_BASE_IMAGE
+
+FROM ${COMMON_BASE_IMAGE}
+
+ARG ENABLE_PRC_NETWORK
+ARG NO_POC_PLATFORM
+ARG IS_XEON_PLATFORM
+
+USER root
+
+# hadolint ignore=DL4006,SC3040
+RUN set -e -o pipefail; \
+    if [ "$IS_XEON_PLATFORM" = "true" ] ; then \
+        apt-get update && apt-get install --no-install-recommends build-essential python3-dev python3-pip python3-setuptools cython3 pciutils git curl unzip numactl wget cmake python3-pip -y; \
+    else \
+        apt-get update && apt-get install --no-install-recommends build-essential python3-dev python3-pip python3-setuptools cython3 pciutils git curl unzip intel-gpu-tools xpu-smi numactl wget cmake python3-pip -y; \
+    fi && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install OpenVINO inside the container
+RUN set -e -o pipefail; \
+    if [ -f /home/dlstreamer/dlstreamer/scripts/install_dependencies/install_openvino.sh ]; then \
+      bash /home/dlstreamer/dlstreamer/scripts/install_dependencies/install_openvino.sh && \
+      ov_dir=$(find /opt/intel -maxdepth 1 -type d -name "openvino_*" | sort -r | head -n 1) && \
+      if [ -n "$ov_dir" ]; then \
+        ln -sf "$ov_dir" /opt/intel/openvino; \
+        echo "Linked $ov_dir -> /opt/intel/openvino"; \
+      else \
+        echo "OpenVINO folder not found after install"; \
+      fi; \
+    else \
+      echo "install_openvino.sh not found in image"; \
+    fi
+
+# Clean up cache to reduce image size
+RUN apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Create necessary folders and set ownership
+# Note: /home/dlstreamer/share will be mounted from esq_data/data/vertical/metro at runtime
+RUN mkdir -p /home/dlstreamer/output && \
+    mkdir -p /home/dlstreamer/share/models && \
+    mkdir -p /home/dlstreamer/share/images && \
+    chown -R dlstreamer:dlstreamer /home/dlstreamer/output && \
+    chown -R dlstreamer:dlstreamer /home/dlstreamer/share && \
+    chmod -R 777 /home/dlstreamer/output
+
+# Copy requirements
+COPY  --chown=dlstreamer:dlstreamer requirements.txt ./
+
+# Install dependencies
+RUN pip install --no-cache-dir --break-system-packages -r requirements.txt
+
+USER dlstreamer
+ENV HOME=/home/dlstreamer
+WORKDIR /home/dlstreamer
+
+# Entrypoint will handle setting up OpenVINO environment
+COPY  --chown=dlstreamer:dlstreamer entrypoint.sh ./
+RUN chmod +x entrypoint.sh
+
+# Copy run script
+COPY --chown=dlstreamer:dlstreamer AI_box_runtimeDL.py .
+COPY --chown=dlstreamer:dlstreamer bcmk_telemetry.py gpu_util.py ./
+
+HEALTHCHECK CMD [ "cat", "/dev/null" ]
+ENTRYPOINT ["./entrypoint.sh"]

--- a/src/esq/suites/system/gpu/src/containers/ai_frequency_measure/bcmk_telemetry.py
+++ b/src/esq/suites/system/gpu/src/containers/ai_frequency_measure/bcmk_telemetry.py
@@ -1,0 +1,665 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import copy
+import csv
+import logging
+import os
+import re
+import shutil
+import subprocess  # nosec B404
+import sys
+import threading
+import time
+import traceback
+from datetime import datetime
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+pd.options.mode.chained_assignment = None
+
+import warnings
+
+warnings.simplefilter(action="ignore", category=FutureWarning)
+
+CURR_DIR = os.path.dirname(os.path.abspath(__file__))
+OUTPUT_DIR = Path(f"{CURR_DIR}/output").resolve()
+if not OUTPUT_DIR.exists():
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    handlers=[
+        logging.FileHandler(OUTPUT_DIR / "freq_execution.log"),
+        # logging.StreamHandler()
+    ],
+)
+
+GPU_TOP_RESULT_DICT = {
+    "Freq MHz": ["req", "act"],
+    "IRQ RC6": ["/s", "%"],
+    "Power W": ["gpu", "pkg"],
+    "IMC MiB/s": ["rd", "wr"],
+    "RCS": ["%", "se", "wa"],
+    "BCS": ["%", "se", "wa"],
+    "VCS": ["%", "se", "wa"],
+    "VECS": ["%", "se", "wa"],
+    "CCS": ["%", "se", "wa"],
+    "UNKN/0": ["%", "se", "wa"],
+}
+
+
+def is_intel_xeon():
+    try:
+        with open("/proc/cpuinfo", "r") as f:
+            cpuinfo = f.read()
+        if "Xeon" in cpuinfo:
+            return True
+        elif "XEON" in cpuinfo:
+            return True
+        else:
+            return False
+    except Exception:
+        return False
+
+
+def get_gpu_renders():
+    renders = []
+    output = subprocess.check_output(["ls", "/dev/dri/"], stderr=subprocess.STDOUT, text=True)
+    for line in output.split("\n"):
+        if "renderD" in line or "drm:" in line:
+            renders.append(line.strip().split()[-1])
+
+    return renders
+
+
+def get_physical_cores():
+    try:
+        wlscpu = shutil.which("lscpu")
+        if not wlscpu:
+            raise FileNotFoundError("lscpu not found")
+
+        # Execute the lscpu command and capture its output
+        result = subprocess.run([wlscpu], stdout=subprocess.PIPE, text=True, check=True)
+        output = result.stdout
+
+        # Use regular expressions to find the number of cores per socket and the number of sockets
+        cores_per_socket = int(re.search(r"Core\(s\) per socket:\s*(\d+)", output).group(1))
+        sockets = int(re.search(r"Socket\(s\):\s*(\d+)", output).group(1))
+
+        # Calculate the total number of physical cores
+        total_physical_cores = cores_per_socket * sockets
+
+        return total_physical_cores, sockets
+    except Exception as e:
+        logging.error(f"An error occurred: {e}")
+        return 1
+
+
+def cpu_usage_filter(line):
+    return line is not None and len(line) > 0 and "procs" not in line and "swpd" not in line
+
+
+def gpu_usage_filter(line):
+    return line is not None and len(line.strip()) > 0
+
+
+def dgpu_power_filter(line):
+    return line is not None and len(line.strip()) > 0
+
+
+# def cpu_proc_usage_filter(line):
+#     return line is not None and "benchmark_app" in line
+
+
+# This function will run in a separate thread, collecting usage data
+def collect_usage(command, output_file, event, filter_func):
+    with open(output_file, "w", buffering=1) as f:  # Line buffering
+        process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+
+        cmd_str = " ".join(command)
+        logging.info(f"Starting telemetry: {cmd_str} -> {output_file}")
+
+        line_count = 0
+        while not event.is_set():
+            if "i7z" in command:
+                time.sleep(1)
+            else:
+                line = process.stdout.readline()
+                if line:  # Log if we got any line
+                    if filter_func(line):
+                        f.write(line)
+                        f.flush()  # Ensure data is written immediately
+                        line_count += 1
+                        if line_count == 1:
+                            logging.debug(f"First line written to {output_file}: {line.strip()[:100]}")
+
+        logging.info(f"Stopped telemetry: {cmd_str}, wrote {line_count} lines")
+        if "i7z" in command:
+            _filter_lines = []
+            with open("i7z_output_raw.txt", "r") as f:
+                _filter_lines = f.readlines()
+
+            cpu_phy_core_number, _ = get_physical_cores()
+            filtered_lines = [l for l in _filter_lines if len(l.strip().split()) == (cpu_phy_core_number + 1)]
+
+            with open("i7z_output.txt", "w") as f:
+                f.writelines(filtered_lines)
+
+            process.kill()
+            process.wait()
+        else:
+            process.terminate()
+
+
+def fetch_bcmk_pids():
+    bcmk_pids = []
+    try_count = 0
+    max_try = 6
+    while len(bcmk_pids) == 0 and try_count < max_try:
+        bcmk_pids = get_bcmk_pids()
+        time.sleep(2)
+        try_count += 1
+    return bcmk_pids
+
+
+def collect_usage_after(command, output_file, event, filter_func):
+    bcmk_pids = fetch_bcmk_pids()
+    thread_mem_list = []
+    for i, bcmk_pid in enumerate(bcmk_pids):
+        command = [str(bcmk_pid) if item == "$bcmk_pid" else item for item in command]
+        collect_usage(command, f"{output_file}_s{i + 1}.txt", event, filter_func)
+    else:
+        if bcmk_pids is None or len(bcmk_pids) == 0:
+            logging.error("Cannot found benchmark_app process and collect its memory usage.")
+
+
+def get_bcmk_pids():
+    try:
+        # pid = subprocess.check_output(["pgrep", "-f", "benchmark_app"]).decode('utf-8').strip()
+        result = subprocess.run(["pgrep", "-f", "benchmark_app"], capture_output=True, text=True)
+        pids = result.stdout.strip().split("\n")
+        return [int(pid) for pid in pids if pid]
+    except Exception as e:
+        print(f"Error getting PIDs: {e}")
+    return []
+
+
+def print_trace():
+    exc_type, exc_value, exc_traceback = sys.exc_info()
+    frames = traceback.extract_tb(exc_traceback)
+    for frame in frames:
+        logging.error(f"File: {frame.filename}, Line: {frame.lineno}, Function: {frame.name}, Code: {frame.line}")
+    logging.error("Exception occurred,", exc_info=True)
+
+
+def check_file(file_path):
+    return os.path.exists(file_path) and os.path.getsize(file_path) > 0
+
+
+def eval_cpu_freq(c_freq_file):
+    if not check_file(c_freq_file):
+        return -1.0
+
+    cpu_freq_df = pd.read_csv(c_freq_file, header=None)
+    cpu_freq_df["max_freq"] = cpu_freq_df.iloc[:, 1:].max(axis=1)
+    cpu_freq_df["max_freq"] = cpu_freq_df["max_freq"].astype(float) / 1000
+
+    # cpu_freq_df.iloc[:, 0] = pd.to_datetime(cpu_freq_df.iloc[:, 0], format='%Y-%m-%d %H:%M:%S')
+
+    cpu_freq_df.rename(columns={cpu_freq_df.columns[0]: "date"}, inplace=True)
+    cpu_freq_df["date"] = pd.to_datetime(cpu_freq_df["date"], format="%Y-%m-%d %H:%M:%S")
+    return cpu_freq_df
+
+
+def eval_cpu_usage(cpu_file):
+    if not check_file(cpu_file):
+        return None
+
+    cpu_usage_df = pd.read_csv(cpu_file, sep=r"\s+", header=None)
+
+    tuned_cu_df = cpu_usage_df.iloc[:, [-1, -2, -5, -7, -8]]
+    new_column_names = ["date1", "date2", "us", "sy", "wa"]
+    tuned_cu_df.columns = new_column_names
+
+    tuned_cu_df["date"] = pd.to_datetime(tuned_cu_df["date2"].astype(str) + " " + tuned_cu_df["date1"].astype(str))
+    # tuned_cu_df['date'] = pd.to_datetime(tuned_cu_df['date'].astype(str), format='%Y-%m-%d %H:%M:%S')
+    tuned_cu_df.drop(["date1", "date2"], axis=1, inplace=True)
+
+    tuned_cu_df["sum"] = tuned_cu_df.iloc[:, :3].sum(axis=1)
+
+    _, sock_num = get_physical_cores()
+    if sock_num > 1:
+        tuned_cu_df["sum"] = tuned_cu_df["sum"] * 2
+        tuned_cu_df["sum"] = tuned_cu_df["sum"].where(tuned_cu_df["sum"] <= 100, 99.9)
+    return tuned_cu_df
+
+
+def eval_dgpu_power(dgpu_file):
+    if not check_file(dgpu_file):
+        return None
+
+    lines = []
+    with open(dgpu_file) as f:
+        lines = f.readlines()
+    if len(lines) < 5:
+        return None
+
+    now = datetime.now()
+    current_date = now.strftime("%Y-%m-%d")
+
+    dgpu_power_df = pd.read_csv(dgpu_file, sep=",")
+    dgpu_power_df.columns = dgpu_power_df.columns.str.strip()  # some space char in column
+    dgpu_power_df["Timestamp"] = dgpu_power_df["Timestamp"].str.slice(stop=8)
+    dgpu_power_df["date"] = pd.to_datetime(current_date + " " + dgpu_power_df["Timestamp"])
+
+    # Convert 'GPU Power (W)' column to numeric, replacing N/A with NaN
+    if "GPU Power (W)" in dgpu_power_df.columns:
+        dgpu_power_df["GPU Power (W)"] = pd.to_numeric(dgpu_power_df["GPU Power (W)"], errors='coerce')
+
+        # Check if all values are NaN (all N/A values)
+        if dgpu_power_df["GPU Power (W)"].isna().all():
+            logging.warning(f"All dGPU power values are N/A in {dgpu_file} - power monitoring may not be supported on this platform")
+            return None
+
+    return dgpu_power_df
+
+
+def normalize_engines(*engines: np.ndarray) -> np.ndarray:
+    valid_engines = [e for e in engines if e.size > 0]
+
+    if not valid_engines:
+        raise ValueError("No non-empty input arrays provided.")
+
+    shapes = [e.shape for e in valid_engines]
+    if len(set(shapes)) != 1:
+        raise ValueError(f"Shape mismatch b/w the input arrays: {shapes}")
+
+    stacked = np.column_stack([e.ravel() for e in valid_engines])
+
+    totals = stacked.sum(axis=1)
+
+    if totals.max() > 0:
+        overall_percent = (totals / totals.max()) * 100
+    else:
+        overall_percent = np.zeros_like(totals, dtype=float)
+
+    overall_percent = np.rint(overall_percent).astype(int)
+
+    return overall_percent
+
+
+def eval_gpu_usage(gpu_file):
+    if not check_file(gpu_file):
+        return None
+    lines = []
+    with open(gpu_file) as f:
+        lines = f.readlines()
+    if len(lines) < 8:
+        return None
+
+    catelogy_line = lines[0]
+    title_line = lines[1]
+    data_lines = [l.strip() for l in lines if not l.strip().startswith("Freq") and not l.strip().startswith("req")]
+    data_lines_2d = np.array(
+        [[float(item) if item.replace(".", "", 1).isdigit() else np.nan for item in l.split()] for l in data_lines]
+    )
+    data_lines_2d = data_lines_2d[4:-2]
+
+    three_spaces = "   "
+    two_spaces = "  "
+    while three_spaces in catelogy_line:
+        catelogy_line = catelogy_line.replace(three_spaces, two_spaces)
+
+    result_category = catelogy_line.strip().split(two_spaces)
+    subtitle_list = title_line.strip().split()
+
+    rcs_0_count = catelogy_line.count("RCS")
+
+    gpu_top_dict = copy.deepcopy(GPU_TOP_RESULT_DICT)
+
+    if "Power W" not in result_category and "pkg" in subtitle_list:
+        gpu_top_dict["IRQ RC6"].append("pkg")
+
+    gpu_result_idx_map = {}
+    st_idx = 0
+    for _category in result_category:
+        gpu_result_idx_map[_category] = {}
+        sub_titles = gpu_top_dict.get(_category, [])
+        for st in sub_titles:
+            gpu_result_idx_map[_category][st] = st_idx
+            st_idx += 1
+
+    gpu_freq_idx = gpu_result_idx_map["Freq MHz"]["act"]
+    gpu_freq_list = data_lines_2d[:, gpu_freq_idx]
+
+    gpu_util_idx = 0
+    gpu_rcs_util = np.array([], dtype=float)
+    gpu_ccs_util = np.array([], dtype=float)
+    gpu_bcs_util = np.array([], dtype=float)
+
+    try:
+        if "RCS" in result_category:
+            gpu_util_idx += 1
+            gpu_rcs_idx = gpu_result_idx_map["RCS"]["%"]
+            gpu_rcs_util = data_lines_2d[:, gpu_rcs_idx].astype(float)
+        if "CCS" in result_category:  # and "pkg" not in subtitle_list:
+            gpu_util_idx += 1
+            gpu_ccs_idx = gpu_result_idx_map["CCS"]["%"]
+            gpu_ccs_util = data_lines_2d[:, gpu_ccs_idx].astype(float)
+        if "BCS" in result_category:
+            gpu_util_idx += 1
+            gpu_bcs_idx = gpu_result_idx_map["BCS"]["%"]
+            gpu_bcs_util = data_lines_2d[:, gpu_bcs_idx].astype(float)
+
+        logging.debug(
+            f"GPU engine arrays - RCS: {len(gpu_rcs_util)}, CCS: {len(gpu_ccs_util)}, BCS: {len(gpu_bcs_util)}"
+        )
+        gpu_util = normalize_engines(gpu_rcs_util, gpu_ccs_util, gpu_bcs_util)
+        logging.debug(f"GPU normalized utilization: {len(gpu_util)} samples, mean={gpu_util.mean():.2f}")
+    except Exception as e:
+        logging.error(f"Failed to calculate GPU utilization for {gpu_file}: {type(e).__name__}: {str(e)}")
+        logging.error(f"  RCS util shape: {gpu_rcs_util.shape}, CCS: {gpu_ccs_util.shape}, BCS: {gpu_bcs_util.shape}")
+        # Return None to indicate failure - don't try to create partial dataframe
+        return None
+
+    try:
+        pkg_power_idx = 0
+        if "Power W" not in result_category and "pkg" in subtitle_list:
+            pkg_power_idx = gpu_result_idx_map["IRQ RC6"]["pkg"]
+        else:
+            pkg_power_idx = gpu_result_idx_map["Power W"]["pkg"]
+        pkg_power_list = data_lines_2d[:, pkg_power_idx]
+    except:
+        pkg_power_idx = -1
+
+    # Check if we have valid utilization data before creating dataframe
+    if gpu_util_idx <= 0:
+        logging.warning(f"No valid GPU utilization data for {gpu_file} - cannot create complete dataframe")
+        return None
+
+    if pkg_power_idx >= 0:
+        # gpu_rst = pd.DataFrame(data_lines_2d[:, [gpu_freq_idx, gpu_util_idx, pkg_power_idx]], columns=['gpu_freq', 'gpu_util', 'pkg_power'])
+        gpu_rst = pd.DataFrame(
+            data={
+                "gpu_freq": data_lines_2d[:, gpu_freq_idx].astype(float),
+                "gpu_util": gpu_util,
+                "pkg_power": data_lines_2d[:, pkg_power_idx].astype(float),
+            }
+        )
+    else:
+        # gpu_rst = pd.DataFrame(data_lines_2d[:, [gpu_freq_idx, gpu_util_idx]], columns=['gpu_freq', 'gpu_util'])
+        gpu_rst = pd.DataFrame(data={"gpu_freq": data_lines_2d[:, gpu_freq_idx].astype(float), "gpu_util": gpu_util})
+
+    gpu_rst["gpu_freq"] = gpu_rst["gpu_freq"] / 1000
+
+    return gpu_rst
+
+
+def _start_cpu_usage_thread(event, out_file):
+    # Ensure path is string for subprocess
+    out_file_str = str(out_file) if not isinstance(out_file, str) else out_file
+    thread_cpu = threading.Thread(
+        target=collect_usage, args=(["vmstat", "-w", "-t", "1"], out_file_str, event, cpu_usage_filter)
+    )
+    thread_cpu.start()
+    return thread_cpu
+
+
+def _start_cpu_freq_thread(event, out_file):
+    def write_cpu_freq_to_file():
+        # Ensure path is string for file operations
+        out_file_str = str(out_file) if not isinstance(out_file, str) else out_file
+
+        open(out_file_str, "w").close()
+        with open(out_file_str, "a", newline="") as csvfile:
+            csvwriter = csv.writer(csvfile)
+
+            while not event.is_set():
+                with open("/proc/cpuinfo", "r") as f:
+                    cpuinfo = f.readlines()
+
+                mhz_values = [float(line.split(":")[1].strip()) for line in cpuinfo if "MHz" in line]
+                avg_mhz = sum(mhz_values) / len(mhz_values) if mhz_values else 0
+
+                current_date = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+                csvwriter.writerow([current_date, avg_mhz])
+
+                time.sleep(1)
+
+    thread_c_freq = threading.Thread(target=write_cpu_freq_to_file)
+    thread_c_freq.start()
+    return thread_c_freq
+
+
+def _start_gpu_usage_threads(event, gpu_render_devs):
+    gpu_tds = []
+    for rd in gpu_render_devs:
+        rd_name = rd.split("/")[-1]
+        output_file = OUTPUT_DIR / f"gpu_usage_{rd_name}.txt"
+        thread_gpu = threading.Thread(
+            target=collect_usage,
+            args=(["intel_gpu_top", "-d", f"drm:/dev/dri/{rd}", "-l"], str(output_file), event, gpu_usage_filter),
+        )
+        gpu_tds.append(thread_gpu)
+    for g_td in gpu_tds:
+        g_td.start()
+
+    return gpu_tds
+
+
+def _start_dgpu_power_threads(event, gpu_render_devs):
+    for rd in gpu_render_devs:
+        rd_name = rd.split("/")[-1]
+        if "renderD129" in rd_name:
+            # xpu-smi dump: -d 0 (device index 0), -m 1 (metric dump interval 1 sec)
+            # Device index 0 for dGPU in xpu-smi (different from renderD numbering)
+            output_file = OUTPUT_DIR / "dgpu_power_dump.txt"
+            thread_dgpu = threading.Thread(
+                target=collect_usage,
+                args=(["xpu-smi", "dump", "-d", "0", "-m", "1"], str(output_file), event, dgpu_power_filter),
+            )
+            thread_dgpu.start()
+            return thread_dgpu
+
+    return None
+
+
+def start_telemetry_thread(event):
+    cu_thread = _start_cpu_usage_thread(event, OUTPUT_DIR / "cpu_usage.txt")
+    # cu_bcmk_thread = _start_cpu_usage_4process_thread(event, "cpu_usage_bcmk")
+    cf_thread = _start_cpu_freq_thread(event, OUTPUT_DIR / "cpu_avg_freq.txt")
+    gpu_thread_list = []
+    gpu_render_devices = get_gpu_renders()
+
+    if len(gpu_render_devices) > 0:
+        gpu_thread_list = _start_gpu_usage_threads(event, gpu_render_devices)
+
+        dgpu_power_thread = _start_dgpu_power_threads(event, gpu_render_devices)
+        if dgpu_power_thread is not None:
+            gpu_thread_list.append(dgpu_power_thread)
+
+    return [cu_thread, cf_thread] + gpu_thread_list
+
+
+def telemetry_decorator(func):
+    def wrapper(*args, **kwargs):
+        event = threading.Event()
+        # gpu_render_devices = get_gpu_renders()
+        thread_list = start_telemetry_thread(event)
+        try:
+            result = func(*args, **kwargs)
+        finally:
+            event.set()
+
+        for td in thread_list:
+            td.join()
+
+        return update_telemetry(result)
+
+    return wrapper
+
+
+def _select_best_dgpu(dgpu_candidates):
+    """
+    Select the best performing dGPU from multiple candidates.
+
+    Selection criteria (in priority order):
+    1. Highest average frequency (peak performance)
+    2. Lowest frequency standard deviation (stability/consistency)
+    3. Highest utilization (most engaged)
+
+    Args:
+        dgpu_candidates: List of dicts with keys: device, metrics, freq_avg, freq_stddev, utilization_avg
+
+    Returns:
+        dict: Best dGPU candidate with selection metadata
+    """
+    if not dgpu_candidates:
+        return None
+
+    if len(dgpu_candidates) == 1:
+        best = dgpu_candidates[0]
+        logging.info(f"Single dGPU detected: {best['device']}")
+        return best
+
+    # Sort by: 1) freq_avg DESC, 2) freq_stddev ASC, 3) utilization_avg DESC
+    sorted_candidates = sorted(
+        dgpu_candidates,
+        key=lambda x: (
+            -x['freq_avg'],           # Higher frequency is better (negate for DESC)
+            x['freq_stddev'],         # Lower stddev is better (ASC)
+            -x['utilization_avg']     # Higher utilization is better (negate for DESC)
+        )
+    )
+
+    best = sorted_candidates[0]
+
+    # Log selection details
+    logging.info(f"Multiple dGPUs detected: {len(dgpu_candidates)} devices")
+    for i, candidate in enumerate(sorted_candidates):
+        rank_label = "SELECTED" if i == 0 else f"Rank {i+1}"
+        logging.info(
+            f"  [{rank_label}] {candidate['device']}: "
+            f"freq_avg={candidate['freq_avg']:.2f} GHz, "
+            f"freq_stddev={candidate['freq_stddev']:.4f}, "
+            f"util_avg={candidate['utilization_avg']:.2f}%"
+        )
+
+    return best
+
+
+def _eval_gpu_telemetry(out_result):
+    gpu_usage = {}
+    dgpu_candidates = []  # Collect all dGPU metrics for comparison
+
+    rds = get_gpu_renders()
+
+    if len(rds) == 0:
+        return
+
+    for rd in rds:
+        rd_name = rd.split("/")[-1]
+        if "128" in rd_name:
+            gpu_dev = "igpu"
+        else:
+            gpu_dev = "dgpu"
+
+        gpu_file = OUTPUT_DIR / f"gpu_usage_{rd_name}.txt"
+        gpu_rst = eval_gpu_usage(str(gpu_file))
+
+        if gpu_rst is not None:
+            if gpu_dev == "igpu":
+                # iGPU: use directly (typically only one)
+                gpu_usage[gpu_dev] = gpu_rst
+            else:
+                # dGPU: collect for comparison
+                freq_avg = gpu_rst["gpu_freq"].mean()
+                freq_stddev = gpu_rst["gpu_freq"].std()
+                utilization_avg = gpu_rst["gpu_util"].mean()
+
+                # Validate metrics before adding candidate
+                # Filter out invalid data: freq_avg <= 0.01 GHz (10 MHz) indicates no valid data
+                if freq_avg > 0.01:
+                    dgpu_candidates.append({
+                        "device": rd_name,
+                        "metrics": gpu_rst,
+                        "freq_avg": freq_avg,
+                        "freq_stddev": freq_stddev,
+                        "utilization_avg": utilization_avg
+                    })
+                    logging.debug(
+                        f"Collected dGPU candidate {rd_name}: "
+                        f"freq_avg={freq_avg:.2f}, freq_stddev={freq_stddev:.4f}, util={utilization_avg:.2f}%"
+                    )
+                else:
+                    logging.warning(
+                        f"Skipping dGPU {rd_name} - invalid metrics (freq_avg={freq_avg:.4f} GHz, "
+                        f"util={utilization_avg:.2f}%). GPU telemetry may have failed."
+                    )
+        else:
+            logging.warning(f"Skipping {gpu_dev} data - eval_gpu_usage returned None for {gpu_file}")
+
+    # Select best dGPU from candidates
+    if dgpu_candidates:
+        best_dgpu = _select_best_dgpu(dgpu_candidates)
+        if best_dgpu:
+            gpu_usage["dgpu"] = best_dgpu["metrics"]
+            # Add metadata for visibility
+            gpu_usage["dgpu_device_id"] = best_dgpu["device"]
+            gpu_usage["dgpu_count"] = len(dgpu_candidates)
+            logging.info(
+                f"Selected dGPU: {best_dgpu['device']} (out of {len(dgpu_candidates)} available)"
+            )
+    else:
+        # No valid dGPU candidates found (all had invalid metrics)
+        # This can happen when intel_gpu_top returns all zeros
+        logging.warning(
+            "No valid dGPU candidates with valid metrics. "
+            "All dGPU telemetry may have failed (intel_gpu_top returned zeros)."
+        )
+
+    out_result["GPU_Usage"] = gpu_usage
+
+    dgpu_power_file = OUTPUT_DIR / "dgpu_power_dump.txt"
+    dgpu_power_rst = eval_dgpu_power(str(dgpu_power_file))
+    if dgpu_power_rst is not None:
+        out_result["dGPU_Power"] = dgpu_power_rst
+
+
+def update_telemetry(out_result={}):
+    if out_result is None:
+        out_result = {}
+
+    try:
+        cpu_usage_file = OUTPUT_DIR / "cpu_usage.txt"
+        out_result["CPU_Usage"] = eval_cpu_usage(str(cpu_usage_file))
+        cpu_freq_file = OUTPUT_DIR / "cpu_avg_freq.txt"
+        out_result["CPU_Freq"] = eval_cpu_freq(str(cpu_freq_file))
+        _eval_gpu_telemetry(out_result)
+    except Exception:
+        logging.error("Error occurs whening update Telemetry info:")
+        print_trace()
+
+    return out_result
+
+
+@telemetry_decorator
+def mywd(c, text="hello world"):
+    rst = {"latency": "1", "throughput": "99"}
+    for _i in range(c):
+        print(f"{_i + 1} times to say {text}")
+        time.sleep(1)
+
+    return rst
+
+
+if __name__ == "__main__":
+    rst = mywd(9, "hello world")
+    print(rst["CPU_Usage"].shape)
+    print(rst["CPU_Freq"])
+    print(rst["GPU_Usage"])
+    print(rst.get("dGPU_Power", None))

--- a/src/esq/suites/system/gpu/src/containers/ai_frequency_measure/common.sh
+++ b/src/esq/suites/system/gpu/src/containers/ai_frequency_measure/common.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+ch=("|" "\\" "-" "/")
+time="date \"+%H:%M:%S\".\$((10#\$(date \"+%N\")/1000000))"
+
+baseFileName=$(basename "$0")
+# Check if terminal is available for color output
+if [ -t 1 ] && command -v tput >/dev/null 2>&1 && tput colors >/dev/null 2>&1; then
+    _red=$(tput setaf 1);_green=$(tput setaf 2);_yellow=$(tput setaf 3);_magenta=$(tput setaf 5);_reset=$(tput sgr0)
+else
+    _red="";_green="";_yellow="";_magenta="";_reset=""
+fi
+
+iGPU_Dev_IDs=(A7A9 A7A8 A7A1 A7A0 A721 A720 A78B A78A A789 A788 A783 A782 A781 A780 4907 4905 4680 4682 4688 468A 468B 4690 4692 4693 46D0 46D1 46D2 4626 4628 462A 46A0 46A1 46A2 46A3 46A6 46A8 46AA 46B0 46B1 46B2 46B3 46C0 46C1 46C2 46C3 4C8A 4C8B 4C90 4C9A 4C8C 4C80 4E71 4E61 4E57 4E55 4E51 4571 4557 4555 4551 4541 9A59 9A60 9A68 9A70 9A40 9A49 9A78 9AC0 9AC9 9AD9 9AF8 6420 64B0 7D51 7D67 7D41 7DD1 7DD5 7D45 7D40 7D55 0BD5 0BDA 56C0 56C1 A7AA A7AB A7AC A7AD 4908 4909 46D3 46D4)
+
+dGPU_Dev_IDs=(56B3 56B2 56A4 56A3 56BA 5697 5696 5695 56B1 56B0 56A6 56A5 56A1 56A0 5694 5693 5692 5691 5690 E20B E20C 64A0 7D55 56A2 56BC 56BD 56BB E211 E212)
+
+find_available_gpus()
+{
+  devices=$(lspci -nn | grep -Ei "DISPLAY|VGA")
+
+  # Extract vendor and device IDs from the output
+  vendor_ids=()
+  device_ids=()
+  available_devices=()
+
+  while IFS=" " read -r id_info; do
+    vendor_id=$(echo "$id_info" | sed -n 's/.*\[\([0-9]*\):.*/\1/p')
+    device_id=$(echo "$id_info" | sed -n 's/.*:\([[:alnum:]]*\)].*/\1/p')
+    if [[ "${iGPU_Dev_IDs[*]}" =~ ${device_id^^} ]]; then
+	available_devices+=("iGPU")
+     elif [[ "${dGPU_Dev_IDs[*]}" =~ ${device_id^^} ]]; then
+	available_devices+=("dGPU")
+     fi 
+    vendor_ids+=("$vendor_id")
+    device_ids+=("$device_id")
+  done <<< "$devices"
+}
+
+format_log()
+{
+    body=$1
+    returnCode=$2
+    funcName=$3
+    lineNo=$4
+    detailsLogFile=$5
+    if [ -z "${returnCode}" ];then
+        echo "[$(eval "$time")][$baseFileName][$funcName][line:$lineNo]${body}" 2>&1 | tee -a "$detailsLogFile"
+    elif [ "${returnCode}" -eq 0 ]; then
+        echo "[$(eval "$time")][$baseFileName][$funcName][line:$lineNo]${_green}${body}${_reset}" 2>&1 | tee -a "$detailsLogFile"
+    else
+        echo "[$(eval "$time")][$baseFileName][$funcName][line:$lineNo]${_red}${body}${_reset}" 2>&1 | tee -a "$detailsLogFile"
+    fi
+}
+
+format_log_np()
+{
+    body=$1
+    returnCode=$2
+    funcName=$3
+    lineNo=$4
+    detailsLogFile=$5
+    echo "[$(eval "$time")][$baseFileName][$funcName][line:$lineNo]${body}[return code: $returnCode]" >> "$detailsLogFile" 2>&1
+}
+
+format_log_section()
+{
+    body=$1
+    returnCode=$2
+    funcName=$3
+    lineNo=$4
+    detailsLogFile=$5
+    len=${len:-0}
+    splitStr=$(printf '%0.s-' $(seq 1 $((120 - len > 0 ? 120 - len : 0))))
+
+    echo -e "\n"
+    echo "[$(eval "$time")][$baseFileName][$funcName][line:$lineNo]${splitStr}" | tee -a "$detailsLogFile"
+    echo "[$(eval "$time")][$baseFileName][$funcName][line:$lineNo]${_yellow}${body}${_reset}" 2>&1 | tee -a "$detailsLogFile"
+    echo "[$(eval "$time")][$baseFileName][$funcName][line:$lineNo]${splitStr}" | tee -a "$detailsLogFile"
+}
+
+checkProcessStatus()
+{
+    monitoring=$(pgrep -c "$2")
+    return "$monitoring"
+}
+
+barFormat()
+{
+    index=0
+    APPPID=$1
+    testApplicationName=$2
+    testModuleName=$3
+    testCaseName=$4
+    funcName=$5
+    lineNo=$6
+    detailsLogFile=$7
+    string=${baseFileName}${funcName}${lineNo}${testModuleName}${testCaseName}
+    len=${#string}
+    splitStr=$(printf '%0.s-' $(seq 1 $((120 - len))))
+
+    checkProcessStatus "$testApplicationName" "$APPPID"
+    retCode=$?
+    while [ $retCode -ge 1 ]
+    do
+        retCode=0
+
+	printf "[%-12s][%s][%s][%s][%s][%s]%s[%c]\r" "$(eval "$time")" "${baseFileName}" "${funcName}" "${lineNo}" "${testModuleName}" "${testCaseName}" "${splitStr}" "${ch[$index]}"
+	((index++))
+	(( index = index % 4 ))
+        for ((i=0;i<5;i++))
+        do
+            checkProcessStatus "$testApplicationName" "$APPPID"
+            retCode=$?
+            # retCode=`expr $retCode + $retTemp`
+            sleep 0.1
+        done
+    done
+    wait "$APPPID"
+    returnCode=$?
+    if [ $returnCode -eq 0 ]
+    then
+	printf "[%-12s][%s][%s][%s][%s][%s]%s[%s]\n" "$(eval "$time")" "$baseFileName" "$funcName" "$lineNo" "$testModuleName" "$testCaseName" "$splitStr" "${_green}Pass${_reset}" 2>&1 | tee -a "$detailsLogFile"
+
+    else
+	printf "[%-12s][%s][%s][%s][%s][%s]%s[%s]\n" "$(eval "$time")" "$baseFileName" "$funcName" "$lineNo" "$testModuleName" "$testCaseName" "$splitStr" "${_red}Fail${_reset}" 2>&1 | tee -a "$detailsLogFile"
+    fi
+
+    return $returnCode
+}
+
+

--- a/src/esq/suites/system/gpu/src/containers/ai_frequency_measure/entrypoint.sh
+++ b/src/esq/suites/system/gpu/src/containers/ai_frequency_measure/entrypoint.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+args=("$@")
+
+if [ -f /opt/intel/openvino/setupvars.sh ]; then
+	# shellcheck disable=SC1091
+	source /opt/intel/openvino/setupvars.sh
+else
+    echo "[WARNING] OpenVINO setupvars.sh not found in container. Did you mount it?"
+fi
+
+if [ -f /opt/intel/openvino/samples/cpp/build_samples.sh ]; then
+	if ! (cd /opt/intel/openvino/samples/cpp && ./build_samples.sh > /dev/null); then
+		echo "Build benchmark_app Failed. Stop test."
+		exit 255
+	fi
+else
+	echo "[WARNING] OpenVINO samples build script not found in container."
+fi
+
+echo "OpenVINO environment initialized"
+
+# Validate that share directory is mounted with correct structure
+# Expected: esq_data/data/vertical/metro mounted to /home/dlstreamer/share
+if [ ! -d "/home/dlstreamer/share" ]; then
+    echo "[ERROR] Share directory not found at /home/dlstreamer/share"
+    echo "[ERROR] Expected structure: /home/dlstreamer/share/{models,images,videos}"
+    echo "[ERROR] Ensure data directory (esq_data/data/vertical/metro) is mounted correctly"
+    exit 1
+fi
+
+# Check if models directory exists
+if [ ! -d "/home/dlstreamer/share/models" ]; then
+    echo "[ERROR] Models directory not found at /home/dlstreamer/share/models"
+    echo "[ERROR] Ensure models are downloaded to esq_data/data/vertical/metro/models"
+    ls -la /home/dlstreamer/share/ 2>/dev/null || echo "Share directory not accessible"
+    exit 1
+fi
+
+echo "Share directory validation passed"
+
+exec python3 AI_box_runtimeDL.py "${args[@]}"

--- a/src/esq/suites/system/gpu/src/containers/ai_frequency_measure/gpu_util.py
+++ b/src/esq/suites/system/gpu/src/containers/ai_frequency_measure/gpu_util.py
@@ -1,0 +1,129 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import subprocess   # nosec B404
+import re
+import json
+
+def _get_device_type(device_id):
+    first_char = device_id[0].upper()
+    if first_char in ['4', '9', 'A', 'a']:
+        return "iGPU"
+    elif first_char == '5':
+        return "dGPU"
+    elif first_char == '7':
+        return "iGPU_MTL"
+    else:
+        return "iGPU" ## maybe incorrect
+
+def parse_gpu_types():
+
+    try:
+        # Run lspci safely without shell
+        lspci_out = subprocess.check_output(["lspci", "-nn"], text=True)
+
+        # Apply your grep equivalent in Python
+        lspci_output = "\n".join(
+            line for line in lspci_out.splitlines()
+            if re.search(r"DISPLAY|VGA", line, re.IGNORECASE)
+        )
+
+    except subprocess.CalledProcessError as e:
+        print(f"Error executing lspci command: {e}")
+        return
+
+    device_pattern = re.compile(r'\[([0-9a-fA-F]{4}):([0-9a-fA-F]{4})\]')
+
+    matches = device_pattern.findall(lspci_output)
+
+    devices = []
+    for match in matches:
+        vendor_id, device_id = match
+        device_type = _get_device_type(device_id)
+        devices.append({
+            "device_id": device_id,
+            "device_type": device_type
+        })
+
+    return devices
+
+def parse_igt():
+    command_output = subprocess.check_output(['intel_gpu_top', '-L'], text=True)
+    # command_output = """
+    # card1                    Intel Meteorlake (Gen12)          pci:vendor=8086,device=7D55,card=0
+    # └─renderD128
+    # 
+    # card0                    Intel Dg2 (Gen12)                 pci:vendor=8086,device=56A5,card=0
+    # └─renderD129
+    # """
+    card_pattern = re.compile(
+        r"^(card\d+)\s+(.*?)\s+pci:vendor=(\w+),device=(\w+),card=(\d+)\n└─(renderD\d+)",
+        re.MULTILINE
+    )
+    
+    matches = card_pattern.findall(command_output)
+    
+    cards = []
+    for match in matches:
+        card_id, device_name, vendor, device, card, render_name = match
+        cards.append({
+            "card_id": card_id,
+            "pci_info": f"pci:vendor={vendor},device={device},card={card}",
+            "render_name": render_name
+        })
+        
+    return cards
+
+def _parse_xs_discovery():
+    try:
+        xpu_smi_output = subprocess.check_output(['xpu-smi', 'discovery', '-j'], text=True)
+    except subprocess.CalledProcessError as e:
+        print(f"Error executing xpu-smi command: {e}")
+        return None
+
+    _data = {}
+    try:
+        _data = json.loads(xpu_smi_output)
+    except json.JSONDecodeError as e:
+        print(f"Error decoding JSON: {e}")
+
+    return _data
+
+def get_gpu_devices():
+    xsd_data = _parse_xs_discovery()
+    igt_data = parse_igt()
+    
+    drm_to_card_id = {f"/dev/dri/{info['card_id']}": info for info in igt_data}
+    
+    device_dict = {}
+
+    if xsd_data["device_list"] is None:
+        return device_dict
+
+    for device in xsd_data["device_list"]:
+        drm_device = device["drm_device"]
+        if drm_device in drm_to_card_id:
+            additional_info = drm_to_card_id[drm_device]
+            device["card_id"] = additional_info["card_id"]
+            device["pci_info"] = additional_info["pci_info"]
+
+            pci_device_id = device["pci_device_id"]
+            stripped_device_id = pci_device_id[2:]
+            device["render_name"] = additional_info["render_name"]
+            device_type = _get_device_type(stripped_device_id)
+            device["device_type"] = device_type
+            
+            bcmk_device = f"GPU.{device['device_id']}"
+            device_dict[bcmk_device] = device
+          
+    return device_dict
+
+def main():
+    print("Get GPU Devices: ")
+    gpu_devices = get_gpu_devices()
+    
+    print("\nGet GPU Types:")
+    parse_gpu_types()
+
+if __name__ == "__main__":
+    main()

--- a/src/esq/suites/system/gpu/src/containers/ai_frequency_measure/requirements.txt
+++ b/src/esq/suites/system/gpu/src/containers/ai_frequency_measure/requirements.txt
@@ -1,0 +1,14 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+pycocotools>=2.0.7
+matplotlib==3.9.2
+numpy==1.26.4
+pyarrow==16.1.0
+pandas==2.2.0
+pycocotools==2.0.7
+typing-extensions==4.10.0
+torch==2.8.0
+torchvision
+tensorflow==2.16.1
+openvino

--- a/src/esq/suites/system/gpu/test_system_gpu.py
+++ b/src/esq/suites/system/gpu/test_system_gpu.py
@@ -1,0 +1,938 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import logging
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+import allure
+import pytest
+from esq.utils.genutils import (
+    extract_csv_values,
+)
+from sysagent.utils.config import ensure_dir_permissions
+from sysagent.utils.core import Metrics, Result
+from sysagent.utils.infrastructure import DockerClient
+from sysagent.utils.system.ov_helper import get_available_devices_by_category
+
+logger = logging.getLogger(__name__)
+
+test_container_path = "src/containers/ai_frequency_measure/"
+
+
+def _create_gpu_metrics(device: str, value: Any = -1, unit: Any = None) -> dict:
+    """
+    Create GPU performance metrics dictionary with ALL possible metrics.
+
+    Creates metrics for both iGPU and dGPU, with the tested device marked as key metric.
+    Includes both average performance AND stability metrics (stddev, range) for frequency.
+    This ensures Metro CSV shows -1 for non-tested device metrics instead of empty columns.
+
+    Note: When metrics cannot be retrieved (0 values from gpu_top tool, test interrupts, or failures),
+    they are reported as -1 with no unit to avoid confusing displays like "-1 %".
+
+    Args:
+        device: Device type being tested - "dgpu" or "igpu"
+        value: Initial value for all metrics (default: -1 for missing/unavailable data)
+        unit: Unit for metrics (default: None for -1 values, set appropriately for valid data)
+
+    Returns:
+        Dictionary of Metrics objects for ALL device types (both iGPU and dGPU)
+    """
+    # Determine which device metric is the key metric based on device being tested
+    is_dgpu = device == "dgpu"
+
+    return {
+        # dGPU metrics - Performance
+        "frequency_max_dgpu": Metrics(unit=unit, value=value, is_key_metric=is_dgpu),
+        "utilization_dgpu": Metrics(unit=unit, value=value, is_key_metric=False),
+        "max_power_dgpu": Metrics(unit=unit, value=value, is_key_metric=False),
+        # dGPU metrics - Stability (lower is better for stability)
+        "frequency_stddev_dgpu": Metrics(unit=unit, value=value, is_key_metric=False),
+        "frequency_min_dgpu": Metrics(unit=unit, value=value, is_key_metric=False),
+        "frequency_range_dgpu": Metrics(unit=unit, value=value, is_key_metric=False),
+        # iGPU metrics - Performance
+        "frequency_max_igpu": Metrics(unit=unit, value=value, is_key_metric=not is_dgpu),
+        "utilization_igpu": Metrics(unit=unit, value=value, is_key_metric=False),
+        "max_power_igpu": Metrics(unit=unit, value=value, is_key_metric=False),
+        # iGPU metrics - Stability (lower is better for stability)
+        "frequency_stddev_igpu": Metrics(unit=unit, value=value, is_key_metric=False),
+        "frequency_min_igpu": Metrics(unit=unit, value=value, is_key_metric=False),
+        "frequency_range_igpu": Metrics(unit=unit, value=value, is_key_metric=False),
+        # CPU metrics (common to both)
+        "utilization_cpu": Metrics(unit=unit, value=value, is_key_metric=False),
+        "frequency_max_cpu": Metrics(unit=unit, value=value, is_key_metric=False),
+    }
+
+@allure.title("System GPU Performance Test (OpenVINO)")
+def test_system_gpu(
+    request,
+    configs,
+    cached_result,
+    cache_result,
+    get_kpi_config,
+    validate_test_results,
+    summarize_test_results,
+    validate_system_requirements_from_configs,
+    execute_test_with_cache,
+    prepare_test,
+):
+    # Request
+    test_name = request.node.name.split("[")[0]
+    # Parameters
+    test_id = configs.get("test_id", test_name)
+    test_display_name = configs.get("display_name", test_name)
+
+    logger.info(f"Starting AI Frequency Runner: {test_display_name}")
+
+    duration_hrs = int(configs.get("duration_hrs", 0.15))
+    dockerfile_name = configs.get("dockerfile_name", "Dockerfile")
+    docker_image_tag = (
+        f"{configs.get('container_image', 'metro_dqt_ai_freq_measure')}:{configs.get('image_tag', '3.0')}"
+    )
+    timeout = int(configs.get("timeout", 300))
+    base_image = configs.get("base_image", "intel/dlstreamer:2025.1.2-ubuntu24")
+    device = configs.get("device", "igpu")
+    # Setup
+    test_dir = os.path.dirname(os.path.abspath(__file__))
+    docker_dir = os.path.join(test_dir, test_container_path)
+
+    # Use CORE_DATA_DIR for results: esq_data/data/vertical/metro/results/gpu
+    core_data_dir_tainted = os.environ.get("CORE_DATA_DIR", os.path.join(os.getcwd(), "esq_data"))
+    core_data_dir = "".join(c for c in core_data_dir_tainted)
+    data_dir = os.path.join(core_data_dir, "data", "vertical", "metro")
+    aifreq_results = os.path.join(data_dir, "results", "gpu")
+    os.makedirs(aifreq_results, exist_ok=True)
+
+    # Ensure directories have correct permissions
+    ensure_dir_permissions(aifreq_results, uid=os.getuid(), gid=os.getgid(), mode=0o775)
+
+    # Initialize result template early (BEFORE validation) to ensure test info is available even if skipped
+    # This ensures Metro CSV shows proper test name and -1 metrics (indicating data not available)
+    metrics = _create_gpu_metrics(device, value=-1, unit=None)
+
+    results = Result.from_test_config(
+        configs=configs,
+        parameters={
+            "timeout(s)": timeout,
+            "display_name": test_display_name,
+            "device": device,
+        },
+        metrics=metrics,
+        metadata={
+            "status": "N/A",
+        },
+    )
+
+    # Step 1: Validate system requirements (Computation devices, memory, storage, Docker, etc.)
+    # If validation fails, test will be skipped but result object already initialized above
+    try:
+        validate_system_requirements_from_configs(configs)
+    except (pytest.skip.Exception, pytest.fail.Exception):
+        # Test is being skipped or failed due to requirements not met
+        # Ensure result is summarized before re-raising
+        results.metadata["failure_reason"] = "System requirements not met (validated before device check)"
+        summarize_test_results(
+            results=results,
+            test_name=test_name,
+            configs=configs,
+            get_kpi_config=get_kpi_config,
+        )
+        raise  # Re-raise to preserve skip/fail behavior
+
+    # Get available devices to check before validation
+    logger.info(f"Configured device categories: {device}")
+    device_dict = get_available_devices_by_category(device_categories=device)
+
+    if not device_dict:
+        logger.warning(
+            f"Required {device.upper()} hardware not available to test. "
+            f"Test will complete with -1 metrics (hardware requirement not met)."
+        )
+
+        # Update existing results object with failure reason
+        results.metadata["status"] = "N/A"
+        results.metadata["failure_reason"] = (
+            f"Required {device.upper()} hardware not available to test. "
+            f"Hardware requirement set to {device}_required=true"
+        )
+
+        # Summarize with N/A status
+        summarize_test_results(
+            results=results,
+            test_name=test_name,
+            configs=configs,
+            get_kpi_config=get_kpi_config,
+        )
+
+        # This ensures the error message is displayed in summary and report overview
+        failure_msg = (
+            f"Required {device.upper()} hardware not available on this platform. "
+            f"Hardware requirement set to {device}_required=true. "
+            f"Test completed with -1 metrics (data not available)."
+        )
+        logger.error(f"Test failed: {failure_msg}")
+        pytest.fail(failure_msg)
+
+    docker_client = DockerClient()
+
+    # Initialize variables for finally block (moved to top for broader coverage)
+    # Note: results object already initialized above before validation
+    test_failed = False
+    test_interrupted = False
+    failure_message = ""
+
+    try:
+        # Step 2: Prepare test environment
+        def prepare_assets():
+            # Access outer scope variables
+            nonlocal base_image, docker_image_tag, dockerfile_name, docker_dir, timeout
+
+            docker_nocache = configs.get("docker_nocache", False)
+            logger.info(f"Docker build cache setting: nocache={docker_nocache}")
+
+            # Download models and assets outside container
+            logger.info("Downloading OpenVINO models for GPU benchmarking...")
+            # Use CORE_DATA_DIR structure: esq_data/data/vertical/metro/models and images
+            core_data_dir_tainted = os.environ.get("CORE_DATA_DIR", os.path.join(os.getcwd(), "esq_data"))
+            core_data_dir = "".join(c for c in core_data_dir_tainted)
+            data_dir = os.path.join(core_data_dir, "data", "vertical", "metro")
+            models_dir = os.path.join(data_dir, "models")
+            images_dir = os.path.join(data_dir, "images")
+            videos_dir = os.path.join(data_dir, "videos")
+            results_dir = os.path.join(data_dir, "results", "gpu")  # GPU suite results
+
+            # Create directories
+            os.makedirs(models_dir, exist_ok=True)
+            os.makedirs(images_dir, exist_ok=True)
+            os.makedirs(videos_dir, exist_ok=True)
+            os.makedirs(results_dir, exist_ok=True)
+
+            logger.info(f"Using data directory: {data_dir}")
+
+            try:
+                from esq.utils.models.yolo_model_utils import (
+                    download_test_image,
+                    download_yolo_model,
+                    export_yolo_model,
+                )
+                from sysagent.utils.system.hardware import collect_cpu_info
+
+                # Detect CPU class and select appropriate model
+                def select_model_for_cpu(config_models):
+                    """
+                    Select appropriate YOLO model based on CPU class.
+
+                    - Atom/Celeron: Use YOLOv5n (nano - smallest, fastest)
+                    - Core/Xeon: Use YOLOv5s (small - default)
+                    - Config override: Honor user-specified model
+
+                    Returns:
+                        str: Selected model name
+                    """
+                    # If config explicitly specifies a model, use it
+                    if config_models and config_models != ["yolov5s"]:
+                        logger.info(f"Using model from config: {config_models}")
+                        return config_models
+
+                    # Auto-detect CPU class
+                    try:
+                        cpu_info = collect_cpu_info()
+                        cpu_brand = cpu_info.get("brand", "Unknown").lower()
+
+                        # Check for Atom or Celeron (low-power CPUs)
+                        if "atom" in cpu_brand or "celeron" in cpu_brand:
+                            logger.info(f"Detected low-power CPU: {cpu_info.get('brand')}")
+                            logger.info("Auto-selecting YOLOv5n (nano variant) for optimal performance")
+                            return ["yolov5n"]
+                        else:
+                            logger.info(f"Detected CPU: {cpu_info.get('brand')}")
+                            logger.info("Using YOLOv5s (small variant) - standard model")
+                            return ["yolov5s"]
+                    except Exception as e:
+                        logger.warning(f"Failed to detect CPU class: {e}")
+                        logger.info("Defaulting to YOLOv5s")
+                        return ["yolov5s"]
+
+                # Get model list from test configuration with CPU-based auto-selection
+                # Default: YOLOv5s for Core/Xeon, YOLOv5n for Atom/Celeron
+                config_models = configs.get("models", ["yolov5s"])
+                required_models = select_model_for_cpu(config_models)
+                precision = configs.get("precision", "FP16")
+
+                downloaded_models = {}
+
+                # Download each required model
+                for model_name in required_models:
+                    logger.info(f"Downloading YOLO model: {model_name}")
+                    try:
+                        # Download PyTorch weights (stays in Ultralytics cache)
+                        weights_path = download_yolo_model(model_name, models_dir=models_dir)
+                        if not weights_path:
+                            raise RuntimeError(f"Failed to download {model_name} weights")
+                        logger.info(f"YOLO weights location: {weights_path}")
+
+                        # Export to OpenVINO IR format in esq_data/data/vertical/metro/models directory
+                        model_xml_path = export_yolo_model(
+                            model_id=model_name,
+                            models_dir=models_dir,
+                            model_precision=precision.upper(),
+                            weights_path=weights_path,
+                        )
+                        if not model_xml_path:
+                            raise RuntimeError(f"Failed to export {model_name} to OpenVINO format")
+                        logger.info(f"Exported to OpenVINO IR: {model_xml_path}")
+
+                        # Store the directory path (parent of .xml file) for consistency
+                        model_path = model_xml_path.parent
+                    except Exception as e:
+                        logger.error(f"Failed to download/export YOLO model: {e}", exc_info=True)
+                        raise
+
+                    downloaded_models[model_name] = model_path
+                    logger.info(f"Model {model_name}: prepared at {model_path}")
+
+                # Download test image to images directory
+                test_image = download_test_image("car.png", output_dir=images_dir)
+                if test_image:
+                    downloaded_models["test_image"] = test_image
+                else:
+                    logger.warning("Failed to download test image, test may fail")
+
+                logger.debug(f"Downloaded models: {list(downloaded_models.keys())}")
+
+                # Log directory structure for verification
+                logger.debug("=" * 60)
+                logger.debug(f"Data directory structure: {data_dir}")
+                for subdir in ["models", "images", "videos", "results"]:
+                    subdir_safe = "".join(c for c in subdir)
+                    subdir_path = os.path.join(data_dir, subdir_safe)
+                    if os.path.exists(subdir_path):
+                        items = os.listdir(subdir_path)
+                        logger.debug(f"  {subdir}/: {len(items)} items - {items[:5]}")
+                    else:
+                        logger.warning(f"  {subdir}/: NOT FOUND")
+                logger.debug("=" * 60)
+
+            except Exception as model_error:
+                logger.error(f"Failed to download models: {model_error}", exc_info=True)
+                raise RuntimeError(f"Model preparation failed: {model_error}") from model_error
+
+            build_args = {
+                "COMMON_BASE_IMAGE": f"{base_image}",
+            }
+
+            build_result = docker_client.build_image(
+                path=docker_dir,
+                tag=docker_image_tag,
+                nocache=docker_nocache,
+                dockerfile=dockerfile_name,
+                buildargs=build_args,
+            )
+
+            container_config = {
+                "image_id": build_result.get("image_id", ""),
+                "image_tag": docker_image_tag,
+                "timeout": timeout,
+                "dockerfile": os.path.join(docker_dir, dockerfile_name),
+                "build_path": docker_dir,
+            }
+            result = Result(
+                metadata={
+                    "status": True,
+                    "container_config": container_config,
+                    "Timeout (s)": timeout,
+                    "Display Name": test_display_name,
+                }
+            )
+
+            return result
+
+    except KeyboardInterrupt:
+        failure_message = (
+            f"User interrupt (Ctrl+C) detected during AI Frequency test preparation. "
+            f"Test: {test_display_name}, Device: {device}. "
+            f"Partial setup may be incomplete."
+        )
+        test_interrupted = True
+        logger.error(failure_message)
+        # No containers running yet during preparation phase
+
+    except Exception as e:
+        test_failed = True
+        failure_message = (
+            f"Unexpected error during test preparation: {type(e).__name__}: {str(e)}. "
+            f"Test: {test_display_name}, Device: {device}, Docker image: {docker_image_tag}. "
+            f"Check logs for full stack trace and error details."
+        )
+        logger.error(failure_message, exc_info=True)
+        logger.debug(f"Preparation context - Docker dir: {docker_dir}, Base image: {base_image}")
+        # Don't raise yet - create N/A result below
+
+    try:
+        prepare_test(test_name=test_name, configs=configs, prepare_func=prepare_assets, name="AI_Freq_Assets")
+    except Exception as prep_error:
+        # Handle docker build or other preparation failures
+        test_failed = True
+        failure_message = (
+            f"Test preparation failed during asset setup: {type(prep_error).__name__}: {str(prep_error)}. "
+            f"Possible causes: Docker build failure, model download failure, network issues, or dependency problems. "
+            f"Docker image: {docker_image_tag}, Models: {configs.get('models', ['yolov5s'])}. "
+            f"Check logs for detailed error and verify Docker daemon is running."
+        )
+        logger.error(failure_message, exc_info=True)
+        logger.debug(f"Preparation failed - Docker dir: {docker_dir}, Base image: {base_image}, Timeout: {timeout}s")
+
+    # If preparation failed, update existing results and exit
+    if test_failed:
+        results.metadata["status"] = "N/A"
+        results.metadata["failure_reason"] = failure_message
+
+        # Summarize with N/A status and exit
+        summarize_test_results(
+            results=results,
+            test_name=test_name,
+            configs=configs,
+            get_kpi_config=get_kpi_config,
+        )
+        pytest.fail(failure_message)
+
+    try:
+        def run_test():
+            # Define metrics with -1 as initial values (indicating data not available)
+            # Unit will be set when valid value is populated (unit=None for -1 to avoid "-1 %" display)
+            metrics = _create_gpu_metrics(device, value=-1, unit=None)
+
+            # Initialize result template using from_test_config for automatic metadata application
+            result = Result.from_test_config(
+                configs=configs,
+                parameters={
+                    "test_id": test_id,
+                    "device": device,
+                    "test_duration_hrs": duration_hrs,
+                    "display_name": test_display_name,
+                },
+                metrics=metrics,
+                metadata={
+                    "status": "N/A",
+                },
+            )
+
+            # Check if devices are available
+            if not device_dict:
+                error_msg = (
+                    f"No available devices found for configured device category: '{device}'. "
+                    f"Expected device types: {device}. "
+                    f"Verify hardware availability and driver installation (Intel GPU drivers required)."
+                )
+                logger.error(error_msg)
+                logger.debug(f"Test configuration - device category: {device}, display_name: {test_display_name}")
+                result.metadata["failure_reason"] = error_msg
+                return result
+
+            # Log detailed device information and execute test
+            # Initialize variables for exception handler scope and cleanup tracking
+            model_name = configs.get("models", ["yolov5s"])[0]
+            container_image = configs.get("container_image", "ai_freq_measure")
+            container_tag = configs.get("image_tag", "1.0")
+            container_full_tag = f"{container_image}:{container_tag}"
+            container_name = None  # Track container for cleanup on interrupts
+
+            try:
+                # Container will create averages_summary.csv with results
+                # CSV columns (in order): Function, frequency_max_igpu, utilization_igpu, max_power_igpu,
+                #                         frequency_max_dgpu, utilization_dgpu, max_power_dgpu,
+                #                         utilization_cpu, frequency_max_cpu
+                csv_file_path = Path(f"{aifreq_results}/averages_summary.csv")
+                logger.info(f"Results will be written to: {csv_file_path}")
+
+                # Get container configuration
+                container_image = configs.get("container_image", "ai_freq_measure")
+                container_tag = configs.get("image_tag", "1.0")
+                container_name = f"{container_image}_{device}_{test_id}"
+                container_full_tag = f"{container_image}:{container_tag}"
+
+                # Setup mount paths
+                cl_cache_dir = Path(os.getcwd()) / "cl_cache"
+                cl_cache_dir.mkdir(parents=True, exist_ok=True)
+
+                # Build volume mounts (including system paths for intel_gpu_top)
+                volumes = {
+                    str(aifreq_results): {"bind": "/home/dlstreamer/output", "mode": "rw"},
+                    str(cl_cache_dir): {"bind": "/home/dlstreamer/cl_cache", "mode": "rw"},
+                    "/sys/bus/pci": {"bind": "/sys/bus/pci", "mode": "ro"},  # PCI device info for GPU
+                    "/proc/cpuinfo": {"bind": "/proc/cpuinfo", "mode": "ro"},  # CPU info
+                }
+
+                # Add data directory mount (models/images from esq_data/data/vertical/metro)
+                if os.path.exists(data_dir):
+                    volumes[str(data_dir)] = {"bind": "/home/dlstreamer/share", "mode": "ro"}
+                    logger.info(f"Mounting data directory: {data_dir} -> /home/dlstreamer/share")
+                else:
+                    logger.warning(f"Data directory not found: {data_dir}")
+
+                # Build device mounts for GPU access
+                devices = ["/dev/dri:/dev/dri"]
+                if Path("/dev/accel").exists():
+                    devices.append("/dev/accel:/dev/accel")
+
+                # Get renderD128 and video group IDs for GPU access permissions
+                group_add = []
+                try:
+                    render_stat = os.stat("/dev/dri/renderD128")
+                    render_gid = render_stat.st_gid
+                    group_add.append(str(render_gid))
+                    logger.debug(f"Adding render group: {render_gid}")
+                except Exception as e:
+                    logger.warning(f"Failed to get renderD128 group ID: {e}")
+
+                # Also add video group if different from render
+                try:
+                    import grp
+
+                    video_group = grp.getgrnam("video")
+                    video_gid = video_group.gr_gid
+                    if str(video_gid) not in group_add:
+                        group_add.append(str(video_gid))
+                        logger.debug(f"Adding video group: {video_gid}")
+                except Exception as e:
+                    logger.debug(f"Video group not found or not needed: {e}")
+
+                # Build environment variables
+                environment = {
+                    "MODEL_NAME": model_name,
+                }
+
+                for device_id, device_info in device_dict.items():
+                    logger.info(
+                        f"Device {device_id}: Type={device_info['device_type']}, Name={device_info['full_name']}"
+                    )
+
+                    # Run container using docker_client API
+                    logger.info(f"Running FreqRunner container: {container_full_tag}")
+
+                    try:
+                        # Run container with CAP_PERFMON and CAP_SYS_ADMIN for intel_gpu_top performance monitoring
+                        # Kernel requirement: 5.8+ (CAP_PERFMON), older kernels may need only SYS_ADMIN
+                        # Running as root for now - GPU telemetry requires root for full access
+                        logger.debug(
+                            f"Running container: {container_full_tag} with CAP_PERFMON and CAP_SYS_ADMIN as root"
+                        )
+
+                        logger.debug("Container parameters:")
+                        logger.debug(f"  - Image: {container_full_tag}")
+                        logger.debug(f"  - Name: {container_name}")
+                        logger.debug(f"  - Command: [{device_id}, {duration_hrs}]")
+                        logger.debug(f"  - Volumes: {volumes}")
+                        logger.debug(f"  - Devices: {devices}")
+                        logger.debug(f"  - Environment: {environment}")
+                        logger.debug("  - Capabilities: ['PERFMON', 'SYS_ADMIN']")
+                        logger.debug("  - User: root:root")
+                        logger.debug(f"  - Group add: {group_add}")
+
+                        # Use framework's run_container API with cap_add support
+                        # Note: Framework automatically fails test if container exits with non-zero code
+                        # CRITICAL: remove=False to preserve container until results are copied via volume mount
+                        try:
+                            container_result = docker_client.run_container(
+                                name=container_name,
+                                image=container_full_tag,
+                                command=[str(device_id), str(duration_hrs)],
+                                volumes=volumes,
+                                devices=devices,
+                                environment=environment,
+                                user="root:root",
+                                group_add=group_add,
+                                cap_add=["PERFMON", "SYS_ADMIN"],  # Required for intel_gpu_top
+                                timeout=timeout,
+                                mode="batch",  # Wait for container to complete
+                                attach_logs=True,  # Automatically attach logs to Allure
+                                detach=True,  # Must be True for batch mode
+                                remove=False,  # Keep container until results are read from volume
+                            )
+                        except pytest.fail.Exception as fail_ex:
+                            # Framework auto-fails on non-zero exit code, catch and handle ourselves
+                            error_msg = (
+                                f"Container execution failed: {str(fail_ex)}. "
+                                f"Device: {device_id}, Container: {container_full_tag}. "
+                                f"Check attached container logs for details."
+                            )
+                            logger.error(error_msg)
+                            result.metadata["failure_reason"] = error_msg
+                            result.metadata["status"] = "N/A"
+                            return result
+
+                        # Extract container info from result
+                        container_info = container_result.get("container_info", {})
+                        exit_code = container_info.get("exit_code", -1)
+
+                        logger.debug(f"Container completed with exit code: {exit_code}")
+
+                        logger.info("FreqRunner execution completed successfully")
+
+                    except KeyboardInterrupt:
+                        # User interrupt during container execution
+                        error_msg = (
+                            f"User interrupt (Ctrl+C) during container execution for device '{device_id}'. "
+                            f"Container: {container_name}, Test will be terminated and cleaned up."
+                        )
+                        test_interrupted = True
+                        logger.error(error_msg)
+                        result.metadata["failure_reason"] = error_msg
+                        result.metadata["status"] = "N/A"
+                        # Let finally block handle cleanup
+
+                    except Exception as container_error:
+                        error_msg = (
+                            f"Container execution exception for device '{device_id}': "
+                            f"{type(container_error).__name__}: {str(container_error)}. "
+                            f"Container: {container_full_tag}, Model: {model_name}. "
+                            f"Check if Docker image exists and GPU device is accessible."
+                        )
+                        logger.error(error_msg, exc_info=True)
+                        result.metadata["failure_reason"] = error_msg
+                        result.metadata["status"] = "N/A"
+                        return result
+
+                    finally:
+                        # Always cleanup container, even on interrupts/exceptions
+                        if container_name:
+                            try:
+                                logger.debug(f"Cleaning up container: {container_name}")
+                                docker_client.cleanup_container(container_name, timeout=10)
+                                logger.debug(f"Successfully cleaned up container: {container_name}")
+                            except Exception as cleanup_err:
+                                logger.warning(
+                                    f"Container cleanup warning for {container_name}: {cleanup_err}. "
+                                    "Container may need manual cleanup."
+                                )
+
+                csv_file_path = Path(f"{aifreq_results}/averages_summary.csv")
+                logger.debug(f"Checking for CSV file at: {csv_file_path}")
+                logger.debug(f"CSV file exists: {csv_file_path.exists()}")
+
+                if csv_file_path.exists():
+                    # Log CSV file contents for debugging
+                    try:
+                        with open(csv_file_path, "r") as f:
+                            csv_contents = f.read()
+                        logger.debug(f"CSV file contents ({len(csv_contents)} bytes):")
+                        logger.debug(f"\n{csv_contents}")
+                    except Exception as e:
+                        logger.warning(f"Could not read CSV for debugging: {e}")
+
+                    # Extract KPI values from test results
+                    # Update metrics in-place (they're already part of result object)
+                    logger.debug(f"Extracting {len(metrics)} metrics from CSV...")
+                    for kpi_name, metric_obj in metrics.items():
+                        logger.debug(f"Extracting metric: {kpi_name}")
+                        val = extract_csv_values(csv_file_path, "Function", "AI-Freq-LR", kpi_name)
+                        logger.debug(f"  -> Raw value from CSV: {val}")
+                        if val is not None:
+                            # Convert 0 or 0.0 values to -1 (indicating failed/missing data)
+                            # This handles cases where gpu_top tool couldn't retrieve the metric
+                            try:
+                                numeric_val = float(val)
+                                if numeric_val == 0.0:
+                                    metric_obj.value = -1
+                                    # Skip unit for -1 values (avoid "-1 %" etc.)
+                                    metric_obj.unit = None
+                                    logger.debug(f"  -> Converted 0 to -1 for {kpi_name} (data not available)")
+                                else:
+                                    metric_obj.value = val
+                                    # Set appropriate unit based on metric type
+                                    if "frequency" in kpi_name:
+                                        metric_obj.unit = "GHz"
+                                    elif "utilization" in kpi_name:
+                                        metric_obj.unit = "%"
+                                    elif "power" in kpi_name:
+                                        metric_obj.unit = "W"
+                                    logger.debug(f"  -> Updated KPI {kpi_name}: value={val}, unit={metric_obj.unit}")
+                            except (ValueError, TypeError):
+                                # Non-numeric value - keep as-is
+                                metric_obj.value = val
+                                logger.debug(f"  -> Non-numeric value for {kpi_name}: {val}")
+                        else:
+                            logger.debug(f"Metric {kpi_name} not found in CSV (may not be applicable for this device)")
+
+                    # Validate key frequency metric - fail test if invalid
+                    # Frequency is the key metric, must be valid for successful test
+                    key_freq_metric = f"frequency_max_{device}"
+                    freq_value = metrics.get(key_freq_metric)
+                    if freq_value and (freq_value.value == -1 or freq_value.value <= 0.01):
+                        error_msg = (
+                            f"Test failed: Key frequency metric '{key_freq_metric}' has invalid value "
+                            f"({freq_value.value} GHz). GPU telemetry tool reported 0.0 or "
+                            f"invalid values, indicating telemetry collection failed. This typically occurs when: "
+                            f"1) GPU driver issues, 2) Insufficient permissions for telemetry, or "
+                            f"3) GPU hardware/firmware problems. Check container logs and verify GPU is accessible."
+                        )
+                        logger.error(error_msg)
+                        result.metadata["failure_reason"] = error_msg
+                        result.metadata["status"] = "N/A"
+                        result.metadata["skip_attachment"] = True  # Skip report attachment for invalid results
+                        return result
+
+                    # Extract dGPU selection metadata from CSV (if present from container)
+                    dgpu_device_id = extract_csv_values(csv_file_path, "Function", "AI-Freq-LR", "dgpu_device_id")
+                    dgpu_count = extract_csv_values(csv_file_path, "Function", "AI-Freq-LR", "dgpu_count")
+
+                    # Add metadata to result for visibility in reports
+                    if dgpu_device_id and str(dgpu_device_id) != "N/A":
+                        result.metadata["dgpu_device_id"] = str(dgpu_device_id)
+                        logger.info(f"dGPU device selected for metrics: {dgpu_device_id}")
+
+                    if dgpu_count is not None and str(dgpu_count) != "N/A":
+                        try:
+                            dgpu_count_int = int(float(str(dgpu_count)))
+                            result.metadata["dgpu_count"] = dgpu_count_int
+                            if dgpu_count_int > 1:
+                                logger.info(f"Multiple dGPUs detected: {dgpu_count_int} devices")
+                                logger.info(
+                                    f"Best device selected ({dgpu_device_id}) based on: "
+                                    "highest avg frequency + lowest stddev (stability)"
+                                )
+                            elif dgpu_count_int == 1:
+                                logger.info("Single dGPU detected")
+                        except (ValueError, TypeError) as e:
+                            logger.debug(f"Could not parse dgpu_count '{dgpu_count}': {e}")
+                else:
+                    # CSV file not found - keep all metrics as -1 and mark as failure
+                    error_msg = (
+                        f"Results CSV file not found at expected location: {csv_file_path}. "
+                        f"Test container may have failed to generate results. "
+                        f"Expected file: averages_summary.csv in {aifreq_results}. "
+                        f"Check container logs for execution errors."
+                    )
+                    logger.error(error_msg)
+                    results_dir_contents = (
+                        list(Path(aifreq_results).iterdir()) if Path(aifreq_results).exists() else "Directory not found"
+                    )
+                    logger.debug(f"Results directory contents: {results_dir_contents}")
+                    result.metadata["failure_reason"] = "Results CSV file not generated by test container"
+                    result.metadata["status"] = "N/A"
+                    return result
+
+                valid_metrics = [m for m in metrics.values() if m.value != -1]
+                if not valid_metrics:
+                    metric_names = list(metrics.keys())
+                    error_msg = (
+                        f"Test completed but no valid metrics were collected (all -1). "
+                        f"Expected metrics: {', '.join(metric_names)}. "
+                        f"CSV file was found but metric extraction failed. "
+                        f"Verify CSV format matches expected structure with 'Function' column."
+                    )
+                    logger.error(error_msg)
+                    logger.debug(f"CSV file location: {csv_file_path}")
+                    result.metadata["failure_reason"] = error_msg
+                    result.metadata["status"] = "N/A"
+                    return result
+
+                # If successfully processed all devices and collected valid metrics, mark as success
+                result.metadata["status"] = True
+                result.metadata.pop("failure_reason", None)  # Remove failure_reason if test succeeded
+
+            except Exception as exec_error:
+                # Handle any execution errors (container execution, CSV parsing, etc.)
+                error_msg = (
+                    f"Test execution failed with exception: {type(exec_error).__name__}: {str(exec_error)}. "
+                    f"Device: {device}, Model: {model_name}, Duration: {duration_hrs}hrs. "
+                    f"Check logs for stack trace and detailed error information."
+                )
+                logger.error(error_msg, exc_info=True)
+                logger.debug(f"Execution context - Results dir: {aifreq_results}, Container: {container_full_tag}")
+                result.metadata["failure_reason"] = error_msg
+                # Metrics remain as -1 (data not available)
+                return result
+
+            logger.debug(f"Test results: {json.dumps(result.to_dict(), indent=2)}")
+
+            return result
+    except KeyboardInterrupt:
+        failure_message = (
+            f"User interrupt (Ctrl+C) detected during test execution. "
+            f"Test: {test_display_name}, Device: {device}. "
+            f"Test execution was terminated before completion."
+        )
+        test_interrupted = True
+        logger.error(failure_message)
+
+    except Exception as e:
+        test_failed = True
+        failure_message = (
+            f"Unexpected error during test execution: {type(e).__name__}: {str(e)}. "
+            f"Test: {test_display_name}, Device: {device}. "
+            f"Check logs for complete stack trace and error context."
+        )
+        logger.error(failure_message, exc_info=True)
+        logger.debug(f"Execution context - Test ID: {test_id}, Duration: {duration_hrs}hrs")
+
+    # Execute the test with shared fixture
+    results = execute_test_with_cache(
+        cached_result=cached_result,
+        cache_result=cache_result,
+        test_name=test_name,
+        configs=configs,
+        run_test_func=run_test,
+    )
+
+    # Handle N/A status (missing hardware or test failures)
+    if results.metadata.get("status") == "N/A" and "failure_reason" in results.metadata:
+        failure_msg = results.metadata["failure_reason"]
+
+        # Check if failure is due to missing hardware (not a test execution error)
+        is_hardware_missing = "No available devices found" in failure_msg
+
+        if is_hardware_missing:
+            logger.error(f"Test failed - hardware not available: {failure_msg}")
+            logger.info(f"Test summary - ID: {test_id}, Device: {device}, Duration: {duration_hrs}hrs")
+            logger.info(f"-1 metrics will be reported for {device.upper()} (hardware not present)")
+        else:
+            # Actual test execution error - log as error
+            logger.error(f"Test failed with N/A status: {failure_msg}")
+            logger.info(f"Test summary - ID: {test_id}, Device: {device}, Duration: {duration_hrs}hrs")
+
+        summarize_test_results(
+            results=results,
+            test_name=test_name,
+            configs=configs,
+            get_kpi_config=get_kpi_config,
+        )
+
+        pytest.fail(f"GPU AI Frequency test failed - {failure_msg}")
+
+    # Validate test results against KPIs
+    validate_test_results(results=results, configs=configs, get_kpi_config=get_kpi_config, test_name=test_name)
+    try:
+        logger.info(f"Generating test result visualizations (always executed) Results: {results}")
+
+        # Summarize results using the shared fixture
+        summarize_test_results(
+            results=results,
+            test_name=test_name,
+            configs=configs,
+            get_kpi_config=get_kpi_config,
+        )
+    except Exception as summary_error:
+        error_msg = (
+            f"Test result summarization failed: {type(summary_error).__name__}: {str(summary_error)}. "
+            f"Test execution completed but report generation failed. "
+            f"Results may be incomplete in final report."
+        )
+        logger.error(error_msg, exc_info=True)
+        device_keys = list(device_dict.keys()) if device_dict else "None"
+        logger.debug(f"Summary context - Results dir: {aifreq_results}, Device dict: {device_keys}")
+
+    # Attach artifacts (PNG and log files) for tested devices
+    # Skip attachment if test failed due to invalid key metrics (telemetry failure)
+    skip_attachment = results.metadata.get("skip_attachment", False)
+    best_device_id = results.metadata.get("dgpu_device_id")
+    dgpu_count = results.metadata.get("dgpu_count", 0)
+
+    if skip_attachment:
+        logger.warning(
+            "Skipping report attachment - test failed due to invalid key frequency metric. "
+            "GPU telemetry tool reported 0.0 or invalid values."
+        )
+    elif device_dict:
+        # Determine which devices to attach artifacts for
+        devices_to_attach = []
+        dgpu_devices = []
+
+        for device_id, device_info in device_dict.items():
+            device_type = device_info.get("device_type", "unknown")
+            if device_type == "dgpu":
+                dgpu_devices.append(device_id)
+            else:
+                # Always attach non-dGPU devices (iGPU, etc.)
+                devices_to_attach.append((device_id, device_info, ""))
+
+        # For dGPUs: decide based on best device selection from container results
+        if dgpu_devices:
+            if dgpu_count > 1 and best_device_id:
+                # Multiple dGPUs detected - attach only the best device
+                devices_to_attach.append(
+                    (best_device_id, device_dict[best_device_id], f" (Best of {dgpu_count} dGPUs)")
+                )
+                logger.info(f"Multiple dGPUs detected - attaching only best device: {best_device_id}")
+            elif dgpu_count > 1 and not best_device_id:
+                # Multiple dGPUs with no best device (all same performance) - attach first one only
+                first_dgpu = dgpu_devices[0]
+                devices_to_attach.append(
+                    (first_dgpu, device_dict[first_dgpu], f" ({dgpu_count} dGPUs - Equal Performance)")
+                )
+                logger.info(f"Multiple dGPUs with equal performance - attaching first device: {first_dgpu}")
+            elif dgpu_count == 1 and best_device_id:
+                # Single dGPU identified in metadata - attach only that device
+                devices_to_attach.append((best_device_id, device_dict[best_device_id], ""))
+                logger.info(f"Single dGPU - attaching device: {best_device_id}")
+            else:
+                # Fallback: dgpu_count not available or invalid - attach first dGPU only
+                first_dgpu = dgpu_devices[0]
+                devices_to_attach.append((first_dgpu, device_dict[first_dgpu], ""))
+                logger.warning(f"dGPU count metadata not available - attaching first device only: {first_dgpu}")
+
+        logger.info(f"Attaching artifacts for {len(devices_to_attach)} device(s)")
+
+        for device_id, device_info, title_suffix in devices_to_attach:
+            img_prefix = re.sub(r"\W+", "", device_id)
+
+            # Attach PNG report if available
+            img_file_path = Path(f"{aifreq_results}/{img_prefix}_InferencePerformance_FreqPlot.png")
+            if img_file_path.exists():
+                try:
+                    with open(img_file_path, "rb") as f:
+                        allure.attach(
+                            f.read(),
+                            name=f"GPU AI Frequency Report - {device_id}{title_suffix}",
+                            attachment_type=allure.attachment_type.PNG,
+                        )
+                    logger.debug(f"Attached PNG report for device: {device_id}")
+                except Exception as attach_error:
+                    logger.error(
+                        f"Failed to attach PNG for device {device_id}: "
+                        f"{type(attach_error).__name__}: {str(attach_error)}. Image file: {img_file_path}"
+                    )
+            else:
+                logger.debug(f"PNG report not found for device {device_id}: {img_file_path}")
+
+            # Attach log file if available
+            log_file_path = Path(f"{aifreq_results}/{img_prefix}-IntelVideoAIBoxDetails.log")
+            if log_file_path.exists():
+                try:
+                    with open(log_file_path, "r") as f:
+                        allure.attach(
+                            f.read(),
+                            name=f"GPU Frequency Test Log - {device_id}{title_suffix}",
+                            attachment_type=allure.attachment_type.TEXT,
+                        )
+                    logger.debug(f"Attached log file for device: {device_id}")
+                except Exception as attach_error:
+                    logger.warning(f"Failed to attach log for device {device_id}: {attach_error}")
+            else:
+                logger.debug(f"Log file not found for device {device_id}: {log_file_path}")
+    else:
+        logger.warning("No devices available for artifact attachment")
+
+    # Note: Results directory cleanup is handled by 'esq clean --all' command
+    # which clears esq_data/data/vertical/metro/results/gpu along with all other test data
+
+    is_qualification = configs.get("labels", {}).get("type") == "qualification"
+
+    if test_interrupted:
+        logger.info("All running containers have been stopped and removed.")
+        if is_qualification:
+            pytest.fail(failure_message)
+        else:
+            logger.warning(f"Test interrupted but continuing (suite mode): {failure_message}")
+
+    if test_failed:
+        if is_qualification:
+            pytest.fail(failure_message)
+        else:
+            logger.warning(f"Test failed but continuing (suite mode): {failure_message}")
+
+    logger.info(f"GPU AI Frequency test '{test_name}' completed successfully")

--- a/src/esq/suites/system/memory/test_memory_stream.py
+++ b/src/esq/suites/system/memory/test_memory_stream.py
@@ -10,7 +10,6 @@ import os
 import shutil
 from dataclasses import is_dataclass
 from pathlib import Path
-
 import allure
 import pandas as pd
 import pytest
@@ -22,7 +21,6 @@ from sysagent.utils.infrastructure import DockerClient
 logger = logging.getLogger(__name__)
 
 test_container_path = "src/containers/memory_bcmk/"
-
 
 def _create_mem_metrics(value: str = "N/A", unit: str = None) -> dict:
     """
@@ -41,7 +39,6 @@ def _create_mem_metrics(value: str = "N/A", unit: str = None) -> dict:
         "min_time": Metrics(unit=unit, value=value, is_key_metric=False),
         "max_time": Metrics(unit=unit, value=value, is_key_metric=False),
     }
-
 
 @allure.title("System Memory Performance Test (STREAM)")
 def test_memory_stream(


### PR DESCRIPTION
feat: Integrate AI Frequency long run test suite (#774)

* feat: Integrate AI Frequency long run test suite (#774)
* fix: Add selective metrics for igpu & dgpu and fix scan tool reported issues (#774)
* fix: Standardize metrics and metadata key namings in report summary
* fix: Storage space fixed to support entry level platforms (#774)
* fix: Move utility apis to common place and remove privilege to container (#774)
* fix: Remove B603 notes and align metrics default values (#774)
* fix: Remove openvino dev reference and remove backward compatible apis
* fix: Fix coverity issue and cleanup temp files (#774)
* fix: Add additional error handling for freq runner and remove tar attachments
* fix: Add error codes in error msg with detailed log and attachment
* fix: Rename Metro to MTR and keep profile name same as memory suite
* fix: Resolve bandit scan issue B310, replace urllib.requests with requests
* fix: Remove color logs if execution env/terminal not supporting tput
* chore: Add more debug logs and attach in report
* chore: Legacy X11/XAUTH dependencies cleaned up for GPU Freq suite
* fix: Revert back vertical test case from MTR to METRO
Signed-off-by: Edgard, Arokianadhin <arokianadhin.edgard@intel.com>
