### PR TITLE
fix: text generation model export fails due to OpenVINO minimum version requirement (#937)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "transformers>=4.36",
     "openvino_tokenizers>=2025.2.0.1",
     "Jinja2>=3.1.6",
-    "optimum-intel>=1.26.0",
+    "optimum-intel==1.26.1",
     "ultralytics>=8.3.170",
     "kagglehub>=0.3.13",
     "py-libnuma>=1.2",

--- a/uv.lock
+++ b/uv.lock
@@ -540,7 +540,7 @@ requires-dist = [
     { name = "nncf", specifier = ">=2.17.0" },
     { name = "openvino", specifier = "==2025.2.0" },
     { name = "openvino-tokenizers", specifier = ">=2025.2.0.1" },
-    { name = "optimum-intel", specifier = ">=1.26.0" },
+    { name = "optimum-intel", specifier = "==1.26.1" },
     { name = "psutil", specifier = ">=7.0.0" },
     { name = "py-cpuinfo", specifier = ">=9.0.0" },
     { name = "py-libnuma", specifier = ">=1.2" },
@@ -565,7 +565,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [


### PR DESCRIPTION
fix: text generation model export fails due to OpenVINO minimum version requirement (#937)

* fix: text generation model export fails due to OpenVINO minimum version requirement

- set to fix version of optimum-intel==1.26.1

* fix: include pyproject.toml in test benchmark workflow paths
