### PR TITLE
docs: update missing libgl1 package installation for Ubuntu server setup (#979)

### DIFF
--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -50,7 +50,7 @@ sudo bash -c "$(wget -qLO - https://raw.githubusercontent.com/open-edge-platform
 Install essential system packages:
 
 ```bash
-sudo apt update && sudo apt install -y curl git
+sudo apt update && sudo apt install -y curl git libgl1
 ```
 
 ### 3. Docker Engine


### PR DESCRIPTION
docs: update missing libgl1 package installation for Ubuntu server setup (#979)
