### PR TITLE
chore(deps): bump open-edge-platform/geti-ci from 0.1.1 to 0.1.2 in the github-actions-dependency group (#1218)

### DIFF
--- a/.github/workflows/zizmor-scan.yaml
+++ b/.github/workflows/zizmor-scan.yaml
@@ -58,7 +58,7 @@ jobs:
         with:
           persist-credentials: false
       - name: "Run Zizmor scan"
-        uses: open-edge-platform/geti-ci/actions/zizmor@e80098b3d180db37914f11ff6021f9fa34d0bb9f # zizmor/v0.1.1
+        uses: open-edge-platform/geti-ci/actions/zizmor@0bed754fc7db24b5f9f15e7ead2eb4acdb0c7263 # zizmor/v0.1.2
         with:
           scan-scope: ${{ github.event_name == 'pull_request' && 'changed' || 'all' }}
           severity-level: ${{ github.event_name == 'pull_request' && 'HIGH' || 'LOW' }}


### PR DESCRIPTION
chore(deps): bump open-edge-platform/geti-ci from 0.1.1 to 0.1.2 in the github-actions-dependency group (#1218)
